### PR TITLE
[FEATURE] use checkboxes in frontend list filter for checkbox fields

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -249,11 +249,24 @@ class MailRepository extends AbstractRepository
             // single field search
             foreach ((array)$piVars['filter'] as $field => $value) {
                 if (is_numeric($field) && !empty($value)) {
-                    $filterAnd = [
-                        $query->equals('answers.field', $field),
-                        $query->like('answers.value', '%' . $value . '%')
-                    ];
-                    $filter[] = $query->logicalAnd($filterAnd);
+                    if (is_array(($value))) {
+                        $checkboxesConstraint = [];
+                        foreach ($value as $item) {
+                            $filterAnd = [
+                                $query->equals('answers.field', $field),
+                                $query->like('answers.value', '%"' . $item . '"%')
+                            ];
+                            $checkboxesConstraint[] = $query->logicalAnd($filterAnd);
+                        }
+                        $filter[] = $query->logicalOr($checkboxesConstraint);
+                    } else {
+                        $filterAnd = [
+                            $query->equals('answers.field', $field),
+                            $query->like('answers.value', '%' . $value . '%')
+                        ];
+                        $filter[] = $query->logicalAnd($filterAnd);
+
+                    }
                 }
             }
 

--- a/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -1,0 +1,47 @@
+<?php
+namespace In2code\Powermail\ViewHelpers\Form;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * View helper to generate checkbox fields
+ *
+ * @package TYPO3
+ * @subpackage Fluid
+ */
+class CheckboxViewHelper extends AbstractViewHelper
+{
+
+    /**
+     * Render the tag.
+     *
+     * @param object|array $obj object or array
+     * @param string $prop property name
+     * @param object $field
+     * @return mixed
+     */
+    public function render($obj, $prop, $field)
+    {
+        $checkboxes = array();
+        $searchInput = $obj[$prop];
+
+        if ($settings = $field->getSettings()) {
+            $checkboxSetting = explode("\r\n", $settings);
+            foreach ($checkboxSetting as $checkbox) {
+                $selected = 0;
+
+                $item = explode('|', $checkbox);
+                $checkBoxValue = ($item[1] ? $item[1] : $checkbox);
+
+                if (in_array($checkBoxValue, $searchInput)) {
+                    $selected = 1;
+                }
+                $checkboxes[] = array('label' => $item[0], 'value' => $checkBoxValue, 'selected' => $selected);
+            }
+        }
+        return $checkboxes;
+    }
+
+}

--- a/Resources/Private/Partials/Output/Search.html
+++ b/Resources/Private/Partials/Output/Search.html
@@ -29,11 +29,25 @@
 					{searchField.title}
 				</label>
 				<div class="col-sm-10">
-					<f:form.textfield
-							property="{searchField.uid}"
-							id="powermail_frontend_search_{searchField.marker}"
-							class="powermail_frontend_search powermail_frontend_search_{searchField.marker} form-control"
-							value="{vh:Misc.VariableInVariable(obj:piVars.filter, prop:searchField.uid)}" />
+                <f:if condition="{searchField.type} != 'check'">
+                    <f:form.textfield
+                                property="{searchField.uid}"
+                                id="powermail_frontend_search_{searchField.marker}"
+                                class="powermail_frontend_search powermail_frontend_search_{searchField.marker} form-control"
+                                value="{vh:Misc.VariableInVariable(obj:piVars.filter, prop:searchField.uid)}" />
+                </f:if>
+                <f:if condition="{searchField.type} == 'check'">
+                    <f:for each="{vh:Form.Checkbox(obj:piVars.filter, prop:searchField.uid,field:searchField)}" as="setting" iteration="index">
+                        <f:form.checkbox
+                                    property="{searchField.uid}."
+                                    value="{setting.value}"
+                                    checked="{setting.selected}"
+                                    id="powermail_field_{searchField.marker}_{index.cycle}"
+                                    class="powermail_frontend_search powermail_frontend_search_{searchField.marker}" />
+                        <vh:string.RawAndRemoveXss>{setting.label}</vh:string.RawAndRemoveXss>
+                    </f:for>
+                </f:if>
+
 				</div>
 			</div>
 		</f:for>


### PR DESCRIPTION
Hi Alex,
this renders checkbox-fields in powermail_frontend search fields also as checkboxes to allow easier filtering for the user. By Tayfur Alkoyak and me. Sponsored by Uni Bamberg.
