### PR TITLE
[BUGFIX] #78698: CSV-Export only exports full days

### DIFF
--- a/Classes/Command/TaskCommandController.php
+++ b/Classes/Command/TaskCommandController.php
@@ -251,7 +251,7 @@ class TaskCommandController extends CommandController
         if ($period > 0) {
             $variables = [
                 'filter' => [
-                    'start' => strftime('%Y-%m-%d', (time() - $period)),
+                    'start' => strftime('%Y-%m-%d %H:%M:%S', (time() - $period)),
                     'stop' => 'now'
                 ]
             ];


### PR DESCRIPTION
Allow scheduler to export mails not older than a few hours/minutes.
Currently it only exports the complete day.