### PR TITLE
[FEATURE] Allow Basic Auth Protection for SendParametersFinisher

### DIFF
--- a/Classes/Finisher/SendParametersFinisher.php
+++ b/Classes/Finisher/SendParametersFinisher.php
@@ -92,6 +92,13 @@ class SendParametersFinisher extends AbstractFinisher implements FinisherInterfa
             curl_setopt($curl, CURLOPT_POST, 1);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $curlSettings['params']);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            /* Set username and password for basic auth - if any*/
+            if (!empty($curlSettings['username']) && !empty($curlSettings['password'])) {
+                $username = $curlSettings['username'];
+                $password = $curlSettings['password'];
+                curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+                curl_setopt($curl, CURLOPT_USERPWD, "$username:$password");
+            }
             curl_exec($curl);
             curl_close($curl);
             $this->writeToDevelopmentLog();
@@ -120,6 +127,8 @@ class SendParametersFinisher extends AbstractFinisher implements FinisherInterfa
     {
         return [
             'url' => $this->configuration['targetUrl'],
+            'username' => $this->configuration['username'],
+            'password' => $this->configuration['password'],
             'params' => $this->getValues()
         ];
     }

--- a/Documentation/ForAdministrators/BestPractice/SendingValuesToThirdPartySoftware/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/SendingValuesToThirdPartySoftware/Index.rst
@@ -27,6 +27,10 @@ See TypoScript Settings example:
 				# Target URL for POST values (like http://www.target.com/target.php)
 				targetUrl = http://eloqua.com/e/f.aspx
 
+				# Basic Auth Protection - leave empty if Target is not protected
+				username =
+				password =
+
 				# build your post values like &param1=value1&param2=value2
 				values = COA
 				values {


### PR DESCRIPTION
Add new Typoscript Settings to use Basic Auth Protection in SendParametersFinisher.
If username and password is empty, the target url is called without protection