### PR TITLE
[BUGFIX] Prevent fatal error in \In2code\Powermail\UserFunc\DateConve…

### DIFF
--- a/Classes/UserFunc/DateConverter.php
+++ b/Classes/UserFunc/DateConverter.php
@@ -113,7 +113,9 @@ class DateConverter
     protected function createDateFromFormat()
     {
         $date = \DateTime::createFromFormat($this->getInputFormat(), $this->getInput());
-        $this->setDate($date);
+        if ($date !== false) {
+            $this->setDate($date);
+        }
     }
 
     /**


### PR DESCRIPTION
…rter

As an date field can be optional and have an empty value, the
DateConverter should set its date object only if valid. This prevents
an fatal error like "Argument 1 passed to
In2code\Powermail\UserFunc\DateConverter::setDate() must be an instance
of DateTime, boolean given"