### PR TITLE
[BUGFIX] Wrong page id for new wizard

### DIFF
--- a/Classes/Tca/ShowFormNoteEditForm.php
+++ b/Classes/Tca/ShowFormNoteEditForm.php
@@ -179,20 +179,31 @@ class ShowFormNoteEditForm
      */
     protected function getPageIdentifierForNewForms()
     {
-        $pageIdentifier = (int)$this->params['row']['pid'];
-        if ($pageIdentifier < 0) {
-    		$parentRec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord(
-            	'tt_content',
-            	abs($pageIdentifier),
-            	'pid'
-    		);
-    		$pageIdentifier = $parentRec['pid'];
-		}
+        $pageIdentifier = $this->getPageIdentifierFromExistingContentElements((int) $this->params['row']['pid']);
         $tsConfiguration = BackendUtility::getPagesTSconfig($pageIdentifier);
         if (!empty($tsConfiguration['tx_powermail.']['flexForm.']['newFormPid'])) {
             $pageIdentifier = (int)$tsConfiguration['tx_powermail.']['flexForm.']['newFormPid'];
         }
         return $pageIdentifier;
+    }
+	
+    /**
+     * Get the page identifier for creation of new form if 
+     * there is already another content element in colPos 
+     * of new form plugin
+     *
+     * @return int
+     */
+    protected function getPageIdentifierFromExistingContentElements($pageIdentifier) {	    
+        if ($pageIdentifier < 0) {
+    	    $parentRec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord(
+                'tt_content',
+            	abs($pageIdentifier),
+            	'pid'
+	        );
+            $pageIdentifier = $parentRec['pid'];
+		}
+	    return $pageIdentifier;
     }
 
     /**

--- a/Classes/Tca/ShowFormNoteEditForm.php
+++ b/Classes/Tca/ShowFormNoteEditForm.php
@@ -180,6 +180,14 @@ class ShowFormNoteEditForm
     protected function getPageIdentifierForNewForms()
     {
         $pageIdentifier = (int)$this->params['row']['pid'];
+        if ($pageIdentifier < 0) {
+    		$parentRec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord(
+            	'tt_content',
+            	abs($pageIdentifier),
+            	'pid'
+    		);
+    		$pageIdentifier = $parentRec['pid'];
+		}
         $tsConfiguration = BackendUtility::getPagesTSconfig($pageIdentifier);
         if (!empty($tsConfiguration['tx_powermail.']['flexForm.']['newFormPid'])) {
             $pageIdentifier = (int)$tsConfiguration['tx_powermail.']['flexForm.']['newFormPid'];


### PR DESCRIPTION
If there was already a content element and you call the new wizard to create a form, it fails due to the fact that TYPO3 provides the inverted uid of the content element after which the new one should be placed instead of the page id.