### PR TITLE
Pass $mail to getVariablesWithMarkersFromMail signal

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -396,7 +396,7 @@ class MailRepository extends AbstractRepository
             $variables = ArrayUtility::htmlspecialcharsOnArray($variables);
         }
 
-        $signalArguments = [&$variables, $this];
+        $signalArguments = [&$variables, $this, $mail];
         $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
         return $variables;
     }

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -396,7 +396,7 @@ class MailRepository extends AbstractRepository
             $variables = ArrayUtility::htmlspecialcharsOnArray($variables);
         }
 
-        $signalArguments = [&$variables, $this, $mail];
+        $signalArguments = [&$variables, $mail, $this];
         $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
         return $variables;
     }

--- a/Documentation/ForDevelopers/SignalSlots/Index.rst
+++ b/Documentation/ForDevelopers/SignalSlots/Index.rst
@@ -256,7 +256,7 @@ forge.typo3.org if you need a new signal.
    :Method:
       getVariablesWithMarkersFromMail()
    :Arguments:
-      &$variables, $this
+      &$variables, $mail, $this
    :Description:
       If you want to register your own markers use this signal
 


### PR DESCRIPTION
the getVariablesWithMarkersFromMail signal is ment for adding custom makrers/variables to the template (or modyfing existing ones).
The marker values passed to the signal are already transformed (e.g. converted to string and imploded).
The $mail object is now passed to the slot, so the slot can access field original data.