### PR TITLE
[BUGFIX] load powermail TypoScript in mail standaloneView

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -69,7 +69,8 @@ class TemplateUtility extends AbstractUtility
     {
         $templatePaths = [];
         $extbaseConfig = self::getConfigurationManager()->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            'powermail'
         );
         if (!empty($extbaseConfig['view'][$part . 'RootPaths'])) {
             $templatePaths = $extbaseConfig['view'][$part . 'RootPaths'];


### PR DESCRIPTION
currently, if you want to use your own fluid templates for sent mails, they are not found by powermail (falling back to hardcoded default paths) because the TypoScript configuration `plugin.tx_powermail` is not loaded.