### PR TITLE
[TASK] Exclude non-production files from Git archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/Tests export-ignore
+/Resources/Private/Sass/
+/Resources/Private/gulpfile.js
+/Resources/Private/package.json
+/readme.md
+
+# Enforce checkout with linux lf consistent over all plattforms
+*.html text eol=lf
+*.css text eol=lf
+*.tmpl text eol=lf
+*.less text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.php text eol=lf
+*.rst text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.ts text eol=lf
+*.xlf text eol=lf
+*.sql text eol=lf
+*.t3s text eol=lf
+*.txt text eol=lf


### PR DESCRIPTION
* The .gitattributes file makes exports from github a bit smaller
* by removing not required files for production
* Usefull for composer instalation