### PR TITLE
AjaxFormSubmit IE window.location bug

### DIFF
--- a/Resources/Private/JavaScripts/Powermail/Form.js
+++ b/Resources/Private/JavaScripts/Powermail/Form.js
@@ -218,7 +218,12 @@ function PowermailForm($) {
 						} else {
 							// no form markup found try to redirect via javascript
 							if (redirectUri) {
-								window.location = redirectUri;
+								// Check if internal or external redirect
+								if(redirectUri.indexOf('http')  !== -1) {
+									window.location = redirectUri;
+								} else {
+									window.location.pathname = redirectUri;
+								}
 							} else {
 								// fallback if no location found (but will effect 2x submit)
 								$this.submit();


### PR DESCRIPTION
The problem was, that data-powermail-ajax-uri="event-pages/.../.../" was directly added to current URL in Internet Explorer IE11 and lower.