### PR TITLE
[BUGFIX] Make localized forms selectable

### DIFF
--- a/Classes/Tca/FormSelectorUserFunc.php
+++ b/Classes/Tca/FormSelectorUserFunc.php
@@ -82,7 +82,7 @@ class FormSelectorUserFunc
     {
         $params['items'] = [];
         foreach ($this->getStartPids() as $startPid) {
-            foreach ($this->getAllForms($startPid, $params['row']['sys_language_uid']) as $form) {
+            foreach ($this->getAllForms($startPid, $params['flexParentDatabaseRow']['sys_language_uid']) as $form) {
                 if ($this->hasUserAccessToPage((int)$form['pid'])) {
                     $params['items'][] = [
                         htmlspecialchars($form['title']),


### PR DESCRIPTION
* Due to a breaking change in the core API of TYPO3 CMS 7.6, $params[‘row’] was moved to $params['flexParentDatabaseRow’]. When inserting the powermail plugin (pi1) in the backend, localized forms without a relation to a default language record could not be selected.

See: https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.6/Breaking-70132-FormEngineCustomFunctions.html