### PR TITLE
Use default parsley classHandler for radio fields

### DIFF
--- a/Classes/ViewHelpers/Validation/AbstractValidationViewHelper.php
+++ b/Classes/ViewHelpers/Validation/AbstractValidationViewHelper.php
@@ -116,8 +116,10 @@ abstract class AbstractValidationViewHelper extends AbstractViewHelper
      */
     protected function addClassHandler(array &$additionalAttributes, Field $field)
     {
-        $additionalAttributes['data-parsley-class-handler'] =
-            '.powermail_fieldwrap_' . $field->getMarker() . ' div:first > div';
+        if ($field->getType() !== 'radio') {
+            $additionalAttributes['data-parsley-class-handler'] =
+                '.powermail_fieldwrap_' . $field->getMarker() . ' div:first > div';
+        }
         return $additionalAttributes;
     }
 


### PR DESCRIPTION
Parsley throws an error when two or more fields use the same element as classHandler. To omit this issue, no classHandler is defined for fields of type radio. Parsley will fall back to the default behavior, it attaches the error and success classes to the parent element.