### PR TITLE
[BUGFIX] Field parent pointer of translation overridden in TYPO3 CMS 8

### DIFF
--- a/Configuration/TCA/tx_powermail_domain_model_field.php
+++ b/Configuration/TCA/tx_powermail_domain_model_field.php
@@ -1025,8 +1025,8 @@ $fieldsTca = [
             ],
         ],
         'pages' => [
-            'l10n_mode' => 'exclude',
             'exclude' => 1,
+            'displayCond' => 'FIELD:sys_language_uid:<=:0',
             'label' => 'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
                 Field::TABLE_NAME . '.pages',
             'config' => [


### PR DESCRIPTION
`tx_powermail_domain_model_field.pages` is defined with `l10n_mode=exclude`
which leads the situation that the parent pointer value is overridden
with the value of the default language record of the field entity.

Related: https://forge.typo3.org/issues/80311
Related: https://forge.typo3.org/issues/80281
Fixes: #55