### PR TITLE
Implements https://forge.typo3.org/issues/81015

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -242,8 +242,8 @@
 							<config>
 								<type>text</type>
 								<default>{powermail_all}</default>
+								<enableRichtext>1</enableRichtext>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.receiver.body>
 				</el>
@@ -293,8 +293,8 @@
 							<config>
 								<type>text</type>
 								<default>{powermail_all}</default>
+								<enableRichtext>1</enableRichtext>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.sender.body>
 				</el>
@@ -314,8 +314,8 @@
 							<config>
 								<type>text</type>
 								<default>{powermail_all}</default>
+								<enableRichtext>1</enableRichtext>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.thx.body>
 					<settings.flexform.thx.redirect>


### PR DESCRIPTION
On save CKEditor adds empty p-tags in powermail plugin in RTE-fields

Bug fixed. Side affects should not happen.

Thanks to Thomas Scheibitz (@scheibo_)