### PR TITLE
[FEATURE] Scroll down to form when reloading page

### DIFF
--- a/Resources/Private/Templates/Form/Confirmation.html
+++ b/Resources/Private/Templates/Form/Confirmation.html
@@ -22,6 +22,7 @@ Show Confirmation Page
 			</f:comment>
 			<f:form
 					action="form"
+					section="c{ttContentData.uid}"
 					name="field"
 					enctype="multipart/form-data"
 					class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
@@ -40,6 +41,7 @@ Show Confirmation Page
 			</f:comment>
 			<f:form
 					action="create"
+					section="c{ttContentData.uid}"
 					name="field"
 					enctype="multipart/form-data"
 					class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"

--- a/Resources/Private/Templates/Form/Form.html
+++ b/Resources/Private/Templates/Form/Form.html
@@ -17,6 +17,7 @@ Render Powermail Form
 			<div class="container-fluid">
 				<f:form
 						action="{action}"
+						section="c{ttContentData.uid}"
 						name="field"
 						enctype="multipart/form-data"
 						additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form:form)}"


### PR DESCRIPTION
This scrolls the form into view when submitting the form,
which is helpful for longer pages with the powermail form at the bottom.

Resolves: https://github.com/einpraegsam/powermail/issues/72