### PR TITLE
[PR] backend module list view memory usage fix

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -297,7 +297,16 @@ class MailRepository extends AbstractRepository
      */
     public function findGroupedFormUidsToGivenPageUid($pageUid = 0)
     {
-        $queryResult = $this->findAllInPid($pageUid);
+        /** @var \TYPO3\CMS\Extbase\Persistence\Generic\Query $query */
+        $query     = $this->createQuery();
+        $tableName = $query->getSource()->getSelectorName();
+
+        $sql = 'SELECT MIN(uid) uid,form FROM ' . $tableName . ' WHERE pid = ? AND deleted = 0 GROUP BY form';
+        $prepareStatement = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\PreparedStatement::class, $sql, $tableName);
+
+        $prepareStatement->bindValues([$pageUid]);
+        $query->statement($prepareStatement);
+        $queryResult = $query->execute();
         $forms = [];
         foreach ($queryResult as $mail) {
             /** @var Form $form */

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -301,11 +301,8 @@ class MailRepository extends AbstractRepository
         $query     = $this->createQuery();
         $tableName = $query->getSource()->getSelectorName();
 
-        $sql = 'SELECT MIN(uid) uid,form FROM ' . $tableName . ' WHERE pid = ? AND deleted = 0 GROUP BY form';
-        $prepareStatement = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\PreparedStatement::class, $sql, $tableName);
-
-        $prepareStatement->bindValues([$pageUid]);
-        $query->statement($prepareStatement);
+        $sql = 'SELECT MIN(uid) uid,form FROM ' . $tableName . ' WHERE pid = ' . intval($pageUid) . ' AND deleted = 0 GROUP BY form';
+        $query->statement($sql);
         $queryResult = $query->execute();
         $forms = [];
         foreach ($queryResult as $mail) {


### PR DESCRIPTION
Fix big memory consumption on the backend module list view, by reducing iteration to just unique Forms Uids.

In our TYPO3 we have almost 30k unique mails from one Form and memory was reduced from ~720MB to ~12MB.