### PR TITLE
Make few viewhelpers compilable to improve performance

### DIFF
--- a/Classes/ViewHelpers/Condition/IsArrayViewHelper.php
+++ b/Classes/ViewHelpers/Condition/IsArrayViewHelper.php
@@ -2,6 +2,9 @@
 namespace In2code\Powermail\ViewHelpers\Condition;
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * View helper check if given value is array or not
@@ -9,17 +12,30 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @package TYPO3
  * @subpackage Fluid
  */
-class IsArrayViewHelper extends AbstractViewHelper
+class IsArrayViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
 
     /**
-     * is_array()
+     * Initialize arguments.
      *
-     * @param string|array $val
-     * @return bool
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
      */
-    public function render($val = null)
+    public function initializeArguments()
     {
-        return is_array($val);
+        parent::initializeArguments();
+        $this->registerArgument('val', 'string', 'Value');
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return is_array($arguments['val']);
     }
 }

--- a/Classes/ViewHelpers/Condition/IsDateTimeVariableInVariableViewHelper.php
+++ b/Classes/ViewHelpers/Condition/IsDateTimeVariableInVariableViewHelper.php
@@ -4,6 +4,9 @@ namespace In2code\Powermail\ViewHelpers\Condition;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Is {outer.{inner}} a datetime?
@@ -11,18 +14,33 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @package TYPO3
  * @subpackage Fluid
  */
-class IsDateTimeVariableInVariableViewHelper extends AbstractViewHelper
+class IsDateTimeVariableInVariableViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
+
+    /**
+     * Initialize arguments.
+     *
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('obj', 'object', 'Object', true);
+        $this->registerArgument('prop', 'string', 'Property', true);
+    }
 
     /**
      * Is {outer.{inner}} a datetime?
      *
-     * @param object $obj
-     * @param string $prop Property
-     * @return bool
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string
      */
-    public function render($obj, $prop)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return is_a(ObjectAccess::getProperty($obj, GeneralUtility::underscoredToLowerCamelCase($prop)), '\DateTime');
+        return is_a(ObjectAccess::getProperty($arguments['obj'], GeneralUtility::underscoredToLowerCamelCase($arguments['prop'])), '\DateTime');
     }
 }

--- a/Classes/ViewHelpers/Condition/IsNumberViewHelper.php
+++ b/Classes/ViewHelpers/Condition/IsNumberViewHelper.php
@@ -2,6 +2,9 @@
 namespace In2code\Powermail\ViewHelpers\Condition;
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * View helper check if given value is number or not
@@ -9,17 +12,30 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @package TYPO3
  * @subpackage Fluid
  */
-class IsNumberViewHelper extends AbstractViewHelper
+class IsNumberViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
 
     /**
-     * View helper check if given value is number or not
+     * Initialize arguments.
      *
-     * @param mixed $val
-     * @return bool
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
      */
-    public function render($val = null)
+    public function initializeArguments()
     {
-        return is_numeric($val);
+        parent::initializeArguments();
+        $this->registerArgument('val', 'string', 'Value');
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return is_numeric($arguments['val']);
     }
 }

--- a/Classes/ViewHelpers/Misc/VariableInVariableViewHelper.php
+++ b/Classes/ViewHelpers/Misc/VariableInVariableViewHelper.php
@@ -4,22 +4,42 @@ namespace In2code\Powermail\ViewHelpers\Misc;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class VariableInVariableViewHelper
  */
-class VariableInVariableViewHelper extends AbstractViewHelper
+class VariableInVariableViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
+
+    /**
+     * Initialize arguments.
+     *
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('obj', 'mixed', 'Object', true);
+        $this->registerArgument('prop', 'string', 'Property', true);
+    }
 
     /**
      * Solution for {outer.{inner}} call in fluid
      *
-     * @param mixed $obj object or array
-     * @param string $prop property name
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
      * @return mixed
      */
-    public function render($obj, $prop)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
+        $obj = $arguments['obj'];
+        $prop = $arguments['prop'];
         if (is_array($obj) && array_key_exists($prop, $obj)) {
             return $obj[$prop];
         }

--- a/Classes/ViewHelpers/String/UnderscoredToLowerCamelCaseViewHelper.php
+++ b/Classes/ViewHelpers/String/UnderscoredToLowerCamelCaseViewHelper.php
@@ -3,6 +3,9 @@ namespace In2code\Powermail\ViewHelpers\String;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Underscored value to lower camel case value
@@ -10,17 +13,32 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @package TYPO3
  * @subpackage Fluid
  */
-class UnderscoredToLowerCamelCaseViewHelper extends AbstractViewHelper
+class UnderscoredToLowerCamelCaseViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
+
+    /**
+     * Initialize arguments.
+     *
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('val', 'string', 'Value');
+    }
 
     /**
      * Underscored value to lower camel case value (nice_field => niceField)
      *
-     * @param string $val
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
      * @return string
      */
-    public function render($val = '')
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return GeneralUtility::underscoredToLowerCamelCase($val);
+        return GeneralUtility::underscoredToLowerCamelCase($arguments['val']);
     }
 }


### PR DESCRIPTION
The main motivation is the performance gain, but also in the longer run (TYPO3v9), TYPO3 core will deprecate the usage of arguments on render method. 
Following viewhelpers were changed:
- String/UnderscoredToLowerCamelCaseViewHelper
- Condition/IsArrayViewHelper
- Condition/IsDateTimeVariableInVariableViewHelper
- Condition/IsNumberViewHelper
- Misc/VariableInVariableViewHelper

Other viewhelpers should follow the path. You can test all viewhelpers in one action by trying to export record to xls.