### PR TITLE
[FEATURE] Use default TYPO3 settings when sender name/email is empty

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -4,6 +4,7 @@ namespace In2code\Powermail\Controller;
 use In2code\Powermail\Domain\Model\Mail;
 use In2code\Powermail\Domain\Service\ReceiverMailReceiverPropertiesService;
 use In2code\Powermail\Domain\Service\ReceiverMailSenderPropertiesService;
+use In2code\Powermail\Domain\Service\SenderMailPropertiesService;
 use In2code\Powermail\Utility\ConfigurationUtility;
 use In2code\Powermail\Utility\FrontendUtility;
 use In2code\Powermail\Utility\LocalizationUtility;
@@ -262,6 +263,8 @@ class FormController extends AbstractController
      */
     protected function sendSenderMail(Mail $mail)
     {
+        /** @var SenderMailPropertiesService $senderService */
+        $senderService = $this->objectManager->get(SenderMailPropertiesService::class, $this->settings);
         $email = [
             'template' => 'Mail/SenderMail',
             'receiverEmail' => $this->mailRepository->getSenderMailFromArguments($mail),
@@ -269,10 +272,10 @@ class FormController extends AbstractController
                 $mail,
                 [$this->conf['sender.']['default.'], 'senderName']
             ),
-            'senderEmail' => $this->settings['sender']['email'],
-            'senderName' => $this->settings['sender']['name'],
-            'replyToEmail' => $this->settings['sender']['email'],
-            'replyToName' => $this->settings['sender']['name'],
+            'senderEmail' => $senderService->getSenderEmail(),
+            'senderName' => $senderService->getSenderName(),
+            'replyToEmail' => $senderService->getSenderEmail(),
+            'replyToName' => $senderService->getSenderName(),
             'subject' => $this->settings['sender']['subject'],
             'rteBody' => $this->settings['sender']['body'],
             'format' => $this->settings['sender']['mailformat']

--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -2,8 +2,8 @@
 namespace In2code\Powermail\Controller;
 
 use In2code\Powermail\Domain\Model\Mail;
-use In2code\Powermail\Domain\Service\ReceiverEmailService;
-use In2code\Powermail\Domain\Service\SenderEmailService;
+use In2code\Powermail\Domain\Service\ReceiverMailReceiverPropertiesService;
+use In2code\Powermail\Domain\Service\ReceiverMailSenderPropertiesService;
 use In2code\Powermail\Utility\ConfigurationUtility;
 use In2code\Powermail\Utility\FrontendUtility;
 use In2code\Powermail\Utility\LocalizationUtility;
@@ -222,11 +222,11 @@ class FormController extends AbstractController
      */
     protected function sendReceiverMail(Mail $mail, $hash = null)
     {
-        /** @var ReceiverEmailService $receiverService */
-        $receiverService = $this->objectManager->get(ReceiverEmailService::class, $mail, $this->settings);
+        /** @var ReceiverMailReceiverPropertiesService $receiverService */
+        $receiverService = $this->objectManager->get(ReceiverMailReceiverPropertiesService::class, $mail, $this->settings);
         $mail->setReceiverMail($receiverService->getReceiverEmailsString());
-        /** @var SenderEmailService $senderService */
-        $senderService = $this->objectManager->get(SenderEmailService::class, $mail, $this->settings);
+        /** @var ReceiverMailSenderPropertiesService $senderService */
+        $senderService = $this->objectManager->get(ReceiverMailSenderPropertiesService::class, $mail, $this->settings);
         foreach ($receiverService->getReceiverEmails() as $receiver) {
             $email = [
                 'template' => 'Mail/ReceiverMail',

--- a/Classes/Domain/Service/ReceiverMailReceiverPropertiesService.php
+++ b/Classes/Domain/Service/ReceiverMailReceiverPropertiesService.php
@@ -46,7 +46,7 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
  *
  * @package In2code\Powermail\Domain\Service
  */
-class ReceiverEmailService
+class ReceiverMailReceiverPropertiesService
 {
     use SignalTrait;
 

--- a/Classes/Domain/Service/ReceiverMailSenderPropertiesService.php
+++ b/Classes/Domain/Service/ReceiverMailSenderPropertiesService.php
@@ -32,11 +32,11 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
  ***************************************************************/
 
 /**
- * Class SenderEmailService to get email array for sender attributes
+ * Class ReceiverMailSenderPropertiesService to get email array for sender attributes
  *
  * @package In2code\Powermail\Domain\Service
  */
-class SenderEmailService
+class ReceiverMailSenderPropertiesService
 {
     use SignalTrait;
 
@@ -80,7 +80,7 @@ class SenderEmailService
 
     /**
      * Get sender email from configuration in fields and params. If empty, take default from TypoScript
-     * 
+     *
      * @return string
      */
     public function getSenderEmail()
@@ -91,7 +91,7 @@ class SenderEmailService
             'senderEmail'
         );
         $senderEmail = $this->mailRepository->getSenderMailFromArguments($this->mail, $defaultSenderEmail);
-        
+
         $signalArguments = [&$senderEmail, $this];
         $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
         return $senderEmail;
@@ -99,7 +99,7 @@ class SenderEmailService
 
     /**
      * Get sender name from configuration in fields and params. If empty, take default from TypoScript
-     * 
+     *
      * @return string
      */
     public function getSenderName()
@@ -110,7 +110,7 @@ class SenderEmailService
             'senderName'
         );
         $senderName = $this->mailRepository->getSenderNameFromArguments($this->mail, $defaultSenderName);
-        
+
         $signalArguments = [&$senderName, $this];
         $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
         return $senderName;

--- a/Classes/Domain/Service/SendMailService.php
+++ b/Classes/Domain/Service/SendMailService.php
@@ -433,7 +433,7 @@ class SendMailService
         TypoScriptUtility::overwriteValueFromTypoScript($email['senderEmail'], $this->overwriteConfig, 'senderEmail');
         TypoScriptUtility::overwriteValueFromTypoScript($email['receiverName'], $this->overwriteConfig, 'name');
         if ($this->type !== 'receiver') {
-            // overwrite with TypoScript already done in ReceiverEmailService
+            // overwrite with TypoScript already done in ReceiverMailReceiverPropertiesService
             TypoScriptUtility::overwriteValueFromTypoScript($email['receiverEmail'], $this->overwriteConfig, 'email');
         }
         $parse = [

--- a/Classes/Domain/Service/SenderMailPropertiesService.php
+++ b/Classes/Domain/Service/SenderMailPropertiesService.php
@@ -1,0 +1,114 @@
+<?php
+namespace In2code\Powermail\Domain\Service;
+
+use In2code\Powermail\Signal\SignalTrait;
+use In2code\Powermail\Utility\ConfigurationUtility;
+use In2code\Powermail\Utility\ObjectUtility;
+use In2code\Powermail\Utility\TypoScriptUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Service\TypoScriptService;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Alex Kellner <alexander.kellner@in2code.de>, in2code.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Class SenderMailPropertiesService to get email array for sender attributes
+ * for sender emails
+ *
+ * @package In2code\Powermail\Domain\Service
+ */
+class SenderMailPropertiesService
+{
+    use SignalTrait;
+
+    /**
+     * TypoScript settings as plain array
+     *
+     * @var array
+     */
+    protected $settings = [];
+
+    /**
+     * TypoScript configuration for cObject parsing
+     *
+     * @var array
+     */
+    protected $configuration = [];
+
+    /**
+     * @param array $settings
+     */
+    public function __construct(array $settings)
+    {
+        $this->settings = $settings;
+        /** @var TypoScriptService $typoScriptService */
+        $typoScriptService = ObjectUtility::getObjectManager()->get(TypoScriptService::class);
+        $this->configuration = $typoScriptService->convertPlainArrayToTypoScriptArray($this->settings);
+    }
+
+    /**
+     * Get sender email from form settings. If empty, take default from TypoScript or TYPO3 configuration
+     *
+     * @return string
+     */
+    public function getSenderEmail()
+    {
+        if ($this->settings['sender']['email'] !== '') {
+            $senderEmail = $this->settings['sender']['email'];
+        } else {
+            $senderEmail = ConfigurationUtility::getDefaultMailFromAddress();
+            TypoScriptUtility::overwriteValueFromTypoScript(
+                $senderEmail,
+                $this->configuration['sender.']['default.'],
+                'senderEmail'
+            );
+        }
+
+        $signalArguments = [&$senderEmail, $this];
+        $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
+        return $senderEmail;
+    }
+
+    /**
+     * Get sender name from form settings. If empty, take default from TypoScript or TYPO3 configuration.
+     *
+     * @return string
+     */
+    public function getSenderName()
+    {
+        if ($this->settings['sender']['name'] !== '') {
+            $senderName = $this->settings['sender']['name'];
+        } else {
+            $senderName = ConfigurationUtility::getDefaultMailFromName();
+            TypoScriptUtility::overwriteValueFromTypoScript(
+                $senderName,
+                $this->configuration['sender.']['default.'],
+                'senderName'
+            );
+        }
+
+        $signalArguments = [&$senderName, $this];
+        $this->signalDispatch(__CLASS__, __FUNCTION__, $signalArguments);
+        return $senderName;
+    }
+}

--- a/Configuration/TypoScript/Main/constants.txt
+++ b/Configuration/TypoScript/Main/constants.txt
@@ -115,8 +115,11 @@ plugin.tx_powermail {
 			mailformat = both
 
 			default {
-				# cat=powermail_additional//0430; type=text; label= Default Sender Name: Sendername if no sender name given
-				senderName = Powermail
+				# cat=powermail_additional//0430; type=text; label= Sender Mail - Default Sender Name: Sendername if no sender name given
+				senderName =
+
+				# cat=powermail_additional//0432; type=text; label= Sender Mail - Default Sender Email: Sender email address if no sender email given
+				senderEmail =
 			}
 
 			overwrite {

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -197,6 +197,9 @@ plugin.tx_powermail {
 				mailformat = {$plugin.tx_powermail.settings.sender.mailformat}
 
 				default {
+					senderEmail = TEXT
+					senderEmail.value = {$plugin.tx_powermail.settings.sender.default.senderEmail}
+
 					senderName = TEXT
 					senderName.value = {$plugin.tx_powermail.settings.sender.default.senderName}
 				}

--- a/Documentation/ForDevelopers/SignalSlots/Index.rst
+++ b/Documentation/ForDevelopers/SignalSlots/Index.rst
@@ -151,7 +151,7 @@ forge.typo3.org if you need a new signal.
       Prefill multiple fields by your own magic
 
  - :Class:
-      In2code\\Powermail\\Domain\\Service\\ReceiverEmailService
+      In2code\\Powermail\\Domain\\Service\\ReceiverMailReceiverPropertiesService
    :Name:
       setReceiverEmails
    :Method:
@@ -162,7 +162,7 @@ forge.typo3.org if you need a new signal.
       Manipulate receiver emails short before the mails will be send
 
  - :Class:
-      In2code\\Powermail\\Domain\\Service\\ReceiverEmailService
+      In2code\\Powermail\\Domain\\Service\\ReceiverMailReceiverPropertiesService
    :Name:
       getReceiverName
    :Method:
@@ -195,7 +195,7 @@ forge.typo3.org if you need a new signal.
       Manipulate standaloneView-object before the mail object will be rendered
 
  - :Class:
-      In2code\\Powermail\\Domain\\Service\\SenderEmailService
+      In2code\\Powermail\\Domain\\Service\\ReceiverMailSenderPropertiesService
    :Name:
       getSenderEmail
    :Method:
@@ -206,7 +206,7 @@ forge.typo3.org if you need a new signal.
       Manipulate given sender email
 
  - :Class:
-      In2code\\Powermail\\Domain\\Service\\SenderEmailService
+      In2code\\Powermail\\Domain\\Service\\ReceiverMailSenderPropertiesService
    :Name:
       getSenderName
    :Method:


### PR DESCRIPTION
This is a second take on #74, incorporating the changes you suggested at https://github.com/einpraegsam/powermail/pull/76#issuecomment-301710693

Resolves: #74, #2