### PR TITLE
[FEATURE] Make sender email of spam admin notifications configurable

### DIFF
--- a/Classes/Domain/Validator/SpamShieldValidator.php
+++ b/Classes/Domain/Validator/SpamShieldValidator.php
@@ -161,7 +161,7 @@ class SpamShieldValidator extends AbstractValidator
         if (GeneralUtility::validEmail($this->settings['spamshield']['email'])) {
             MailUtility::sendPlainMail(
                 $this->settings['spamshield']['email'],
-                'powermail@' . GeneralUtility::getIndpEnv('TYPO3_HOST_ONLY'),
+                $this->settings['spamshield']['senderEmail'] ?: 'powermail@' . GeneralUtility::getIndpEnv('TYPO3_HOST_ONLY'),
                 $this->settings['spamshield']['emailSubject'],
                 $this->createSpamNotificationMessage(
                     $this->settings['spamshield']['emailTemplate'],

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -339,6 +339,9 @@ plugin.tx_powermail {
 				# Notification Email to Admin if spam recognized (empty disables email to admin)
 				email = {$plugin.tx_powermail.settings.spamshield.email}
 
+				# Email address sending out spam mail. Set this if your mail transport limits allowed sender addresses
+				senderEmail =
+
 				# Subject for notification Email to Admin
 				emailSubject = {$plugin.tx_powermail.settings.spamshield.emailSubject}
 

--- a/Documentation/ForAdministrators/BestPractice/SpamPrevention/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/SpamPrevention/Index.rst
@@ -242,6 +242,15 @@ Explanation
       \-
 
  - :TyposcriptPath:
+      spamshield.senderEmail
+   :Description:
+      Outgoing email address for spam notifactions. If left empty powermail@[your-domain] will be used. Not needed in most cases.
+   :Type:
+      string
+   :Default:
+      \-
+
+ - :TyposcriptPath:
       spamshield.emailSubject
    :Description:
       Subject for spam-notification-email


### PR DESCRIPTION
This change introduces a new setting,
plugin.tx_powermail.setup.spamshield.senderEmail
If set, outgoing spam notifications will be sent "from" this address.
If left empty, outgoing spam notifications‘ from will default to
powermail@[your-domain] which had been hard-coded so far.

See https://github.com/einpraegsam/powermail/issues/121