### PR TITLE
[BUGFIX] Clear persistenceManager state after findGroupedFormUidsToGivenPageUid

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -309,6 +309,7 @@ class MailRepository extends AbstractRepository
                 }
             }
         }
+        $this->persistenceManager->clearState();
         return $forms;
     }
 


### PR DESCRIPTION
(Resolves Issue #120, not sure if this is actually a bug in Typo3)