### PR TITLE
[BUGFIX] Move RTE configuration from static extension TS to Main Typo…

### DIFF
--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -941,6 +941,9 @@ plugin.tx_powermail {
 	}
 }
 
+# ParseFunc Configuration for using FAL links in receiver and sender mail
+lib.parseFunc_powermail < lib.parseFunc_RTE
+lib.parseFunc_powermail.tags.link.typolink.forceAbsoluteUrl = 1
 
 
 ############################

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -15,12 +15,6 @@ config.tx_extbase {
 	}
 }
 
-# ParseFunc Configuration for using FAL links in receiver and sender mail
-lib.parseFunc_powermail < lib.parseFunc_RTE
-lib.parseFunc_powermail.tags.link.typolink.forceAbsoluteUrl = 1
-
-
-
 
 #################
 # Backend Module


### PR DESCRIPTION
…Script

This correctly formats HTML mails regardless of the
"Static Template Files from TYPO3 Extensions" template setting,
as long as powermail's "Main Template" is included after
the "Content Elements (fluid_styled_content)" template.

Resolves: https://github.com/einpraegsam/powermail/issues/43
Resolves: https://github.com/einpraegsam/powermail/issues/46