### PR TITLE
[BUGFIX] Use 'TSFE:sys_language_uid' instead of 'GP:L' for marketing info

### DIFF
--- a/Configuration/TypoScript/Marketing/setup.txt
+++ b/Configuration/TypoScript/Marketing/setup.txt
@@ -25,7 +25,7 @@ page.3131 {
 	20 = TEXT
 	20 {
 		noTrimWrap = | data-language="|"|
-		data = GP:L
+		data = TSFE:sys_language_uid
 		intval = 1
 	}
 }


### PR DESCRIPTION
Most people use 'L' as the language parameter but this is not mandatory.
