### PR TITLE
[BUGFIX] Update frontendLanguage in marketingAction

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -363,7 +363,7 @@ class FormController extends AbstractController
             ->setMarketingReferer($marketingInfos['referer'])
             ->setMarketingCountry($marketingInfos['country'])
             ->setMarketingMobileDevice($marketingInfos['mobileDevice'])
-            ->setMarketingFrontendLanguage($marketingInfos['frontendLanguage'])
+            ->setMarketingFrontendLanguage($GLOBALS['TSFE']->sys_language_uid)
             ->setMarketingBrowserLanguage($marketingInfos['browserLanguage'])
             ->setMarketingPageFunnel($marketingInfos['pageFunnel']);
         if (FrontendUtility::isLoggedInFrontendUser()) {

--- a/Classes/Utility/SessionUtility.php
+++ b/Classes/Utility/SessionUtility.php
@@ -126,6 +126,9 @@ class SessionUtility extends AbstractUtility
                 'pageFunnel' => [$pid]
             ];
         } else {
+            // update frontend language
+            $marketingInfo['frontendLanguage'] = $language;
+
             // add current pid to funnel
             $marketingInfo['pageFunnel'][] = $pid;
 


### PR DESCRIPTION
Once stored in the session, the frontendLanguage is not updated ever again. 
This means that the language of the first visited page is stored in the DB on form submit. 

The change in 'saveMail()' makes sure that the current frontendLanguage is persisted even if the client has javascript disabled. 
(IMO the frontend language should not be stored in the session at all, but this would be a bigger diff ;)
