### PR TITLE
[TASK] Add getters for $settings, $configuration and $overwriteConfig in sendMailService

### DIFF
--- a/Classes/Domain/Service/SendMailService.php
+++ b/Classes/Domain/Service/SendMailService.php
@@ -481,4 +481,28 @@ class SendMailService
     {
         return $this->type;
     }
+
+    /**
+     * @return array $this->settings
+     */
+    public function getSettings()
+    {
+        return $this->settings;
+    }
+
+    /**
+     * @return array $this->configuration
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @return array $this->overwriteConfig
+     */
+    public function getOverwriteConfig()
+    {
+        return $this->overwriteConfig;
+    }
 }


### PR DESCRIPTION
Add public getters to allow access to protected variables $settings,
$configuration and $overwriteConfig in SignalSlots.