### PR TITLE
Fixes error "e.listen is not a function" when parsley is not included

### DIFF
--- a/Resources/Private/JavaScripts/Powermail/Tabs.js
+++ b/Resources/Private/JavaScripts/Powermail/Tabs.js
@@ -152,7 +152,7 @@ jQuery(document).ready(function($) {
 	 * @return {void}
 	 */
 	function openTabWithError($form, options) {
-		if (options.openTabOnError) {
+		if (options.openTabOnError && $.fn.parsley) {
 			$.listen('parsley:field:error', function() {
 				setTimeout(function() {
 					$form


### PR DESCRIPTION
The function `$.listen` is only defined when `parsley.js` is included. Thus we should check first whether parsley is loaded or not otherwise the following error is thrown:

`Uncaught TypeError: e.listen is not a function`