### PR TITLE
Compare only objects' uids during validation

### DIFF
--- a/Classes/Domain/Validator/InputValidator.php
+++ b/Classes/Domain/Validator/InputValidator.php
@@ -58,7 +58,7 @@ class InputValidator extends StringValidator
     {
         foreach ($mail->getAnswers() as $answer) {
             /** @var Answer $answer */
-            if ($answer->getField() === $field) {
+            if ($answer->getField()->getUid() === $field->getUid()) {
                 return $answer->getValue();
             }
         }


### PR DESCRIPTION
When extending the Model\Files object, the comparison of the $answer->getField() and $field fails and the field validation fails. To make validation work again, the comparison should be reduced to the objects' uid.

See issue #175 for more information