### PR TITLE
[BUGFIX] Do not crash backend module in workspace

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -48,7 +48,7 @@ class PageRepository extends AbstractRepository
     {
         $query = $this->createQuery();
 
-        $sql = 'select title';
+        $sql = 'select uid,title';
         $sql .= ' from pages';
         $sql .= ' where uid = ' . (int)$uid;
         $sql .= ' limit 1';


### PR DESCRIPTION
The automatic language and workspace overlay data loader expects the uid
of a record to be available.

Resolves: https://github.com/einpraegsam/powermail/issues/196