### PR TITLE
[BUGFIX] Log mail sending errors as error, not as warning

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -191,7 +191,7 @@ class FormController extends AbstractController
                 }
             }
         } catch (\Exception $exception) {
-            GeneralUtility::sysLog($exception->getMessage(), 'powermail', GeneralUtility::SYSLOG_SEVERITY_WARNING);
+            GeneralUtility::sysLog($exception->getMessage(), 'powermail', GeneralUtility::SYSLOG_SEVERITY_ERROR);
             $this->addFlashMessage(LocalizationUtility::translate('mail_created_failure'), '', AbstractMessage::ERROR);
         }
     }


### PR DESCRIPTION
TYPO3's syslog is full of warnings so that one does not really want to
log them all, but mail sending failures are something that should
be visible in the log.