### PR TITLE
update "sendTemplateEmailBeforeSend" Signal-Slot

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -366,6 +366,7 @@ class SendMailService
         if ($this->type === 'receiver' && $email['variables']['hash'] === null) {
             $this->mail->setSenderMail($email['senderEmail']);
             $this->mail->setSenderName($email['senderName']);
+            $this->mail->setReceiverMail($email['receiverEmail']);
             $this->mail->setSubject($email['subject']);
         }
     }

--- a/Documentation/ForDevelopers/SignalSlots/Index.rst
+++ b/Documentation/ForDevelopers/SignalSlots/Index.rst
@@ -327,9 +327,9 @@ ext_localconf.php
         \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
     );
     $signalSlotDispatcher->connect(
-        'In2code\Powermail\Domain\Service\SendMailService',
+        'In2code\Powermail\Domain\Service\Mail\SendMailService',
         'sendTemplateEmailBeforeSend',
-        'In2code\Powermailextended\Domain\Service\SendMailService',
+        'In2code\Powermailextended\Domain\Service\Mail\SendMailService',
         'manipulateMail',
         FALSE
     );
@@ -341,9 +341,9 @@ Classes/Domain/Service/SendMailService.php
 ::
 
     <?php
-    namespace In2code\Powermailextended\Domain\Service;
+    namespace In2code\Powermailextended\Domain\Service\Mail;
 
-    use In2code\Powermail\Domain\Service\SendMailService as SendMailServicePowermail;
+    use In2code\Powermail\Domain\Service\Mail\SendMailService as SendMailServicePowermail;
     use TYPO3\CMS\Core\Mail\MailMessage;
 
     /**


### PR DESCRIPTION
- Updated documentary because the namespace for the example has changed.
- Added updating ReceiverMail in Classes/Domain/Service/Mail/SendMailService.php->updateMail() or is there a reason why it's missing?