### PR TITLE
Don't obfuscate email addresses

### DIFF
--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -1001,3 +1001,8 @@ page {
 	}
 }
 [end]
+
+# Make sure that email addresses aren't obfuscated in created emails
+[globalVar = _GET|tx_powermail_pi1|action = create]
+  config.spamProtectEmailAddresses = 0
+[global]


### PR DESCRIPTION
I've got this from https://stackoverflow.com/a/36370090/160968 and I'm very happy about it, as the suggestion from http://www.typo3forum.net/discussion/42345/spamprotectemailaddresses-und-bestaetigungsmails is outdated

I would suggest adding it to the extension TS directly. Not sure if I got the right spot though