### PR TITLE
[TASK] Add field hidden to possible export fields

### DIFF
--- a/Resources/Private/Partials/Module/Export.html
+++ b/Resources/Private/Partials/Module/Export.html
@@ -127,7 +127,7 @@
 						<f:translate key="\In2code\Powermail\Domain\Model\Mail.feuser" />
 					</li>
 				</f:if>
-				<f:if condition="{vh:Condition.IsBackendUserAllowedToViewField(table:'tx_powermail_domain_model_mail',field:'feuser')}">
+				<f:if condition="{vh:Condition.IsBackendUserAllowedToViewField(table:'tx_powermail_domain_model_mail',field:'hidden')}">
 					<li id="hidden" class="list-group-item list-group-item-warning pointer">
 						<f:translate key="LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:LGL.hidden" />
 					</li>

--- a/Resources/Private/Partials/Module/Export.html
+++ b/Resources/Private/Partials/Module/Export.html
@@ -127,6 +127,11 @@
 						<f:translate key="\In2code\Powermail\Domain\Model\Mail.feuser" />
 					</li>
 				</f:if>
+				<f:if condition="{vh:Condition.IsBackendUserAllowedToViewField(table:'tx_powermail_domain_model_mail',field:'feuser')}">
+					<li id="hidden" class="list-group-item list-group-item-warning pointer">
+						<f:translate key="LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:LGL.hidden" />
+					</li>
+				</f:if>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
As hidden can be a crucial information, e.g. regarding double-opt in, it should be available in the export.

Resolves: #229