### PR TITLE
Validation for extended fields

### DIFF
--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -104,7 +104,19 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
         if ($field->getType() !== 'input' && $field->getType() !== 'textarea') {
             return;
         }
+        $this->addValidationAttributesInternal($additionalAttributes, $field);
+    }
+    
 
+    /**
+     * Set different validation attributes (without type check)
+     *
+     * @param array &$additionalAttributes
+     * @param Field $field
+     * @return void
+     */
+    protected function addValidationAttributesInternal(array &$additionalAttributes, Field $field)
+    {
         switch ($field->getValidation()) {
 
             /**


### PR DESCRIPTION
Hi, I am using powermailextended a lot and have create new fields that also are an 'input' although their type name, of course, differs.
With this change I can re-use this method by extending the `ValidationDataAttributeViewHelper`.

A solid solution would be to not use `getType()`  for this type of capability tests at all. Instead, every field needs to declare its capabilities (file upload, multiple, advanced file type, etc.). Currently there are different approaches for this: 
* `isAdvancedFieldType()`, 
* field type in `page.ts`, 
* maybe also `isMultiselect()` etc.