### PR TITLE
[BUGFIX] Remove multi line head tags and further invisible tags

### DIFF
--- a/Classes/Domain/Service/Mail/PlaintextService.php
+++ b/Classes/Domain/Service/Mail/PlaintextService.php
@@ -19,7 +19,7 @@ class PlaintextService
      */
     public function makePlain($content)
     {
-        $content = $this->removeHeadElement($content);
+        $content = $this->removeInvisibleElements($content);
         $content = $this->removeLinebreaksAndTabs($content);
         $content = $this->addLineBreaks($content);
         $content = $this->addSpaceToTableCells($content);
@@ -30,14 +30,31 @@ class PlaintextService
     }
 
     /**
-     * Remove head tag from content
+     * Remove all invisible elements
      *
      * @param string $content
      * @return string
      */
-    protected function removeHeadElement($content)
+    protected function removeInvisibleElements($content)
     {
-        return preg_replace('/<head>(.*?)<\/head>/i', '', $content);
+        $content = preg_replace(
+            [
+                '/<head[^>]*?>.*?<\/head>/siu',
+                '/<style[^>]*?>.*?<\/style>/siu',
+                '/<script[^>]*?>.*?<\/script>/siu',
+                '/<object[^>]*?>.*?<\/object>/siu',
+                '/<embed[^>]*?>.*?<\/embed>/siu',
+                '/<applet[^>]*?>.*?<\/applet>/siu',
+                '/<noframes[^>]*?>.*?<\/noframes>/siu',
+                '/<noscript[^>]*?>.*?<\/noscript>/siu',
+                '/<noembed[^>]*?>.*?<\/noembed>/siu',
+            ],
+            [
+                '', '', '', '', '', '', '', '', ''
+            ],
+            $content
+        );
+        return $content;
     }
 
     /**

--- a/Tests/Unit/Domain/Service/Mail/PlaintextServiceTest.php
+++ b/Tests/Unit/Domain/Service/Mail/PlaintextServiceTest.php
@@ -62,8 +62,12 @@ class PlaintextServiceTest extends UnitTestCase
                 "a\nb\nc\nd"
             ],
             [
-                '<head><title>x</title></head>a<ul><li>b</li><li>c</li></ul>d',
+                "<head>\n\t<title>x</title>\n</head>a<ul><li>b</li><li>c</li></ul>d",
                 "a\nb\nc\nd"
+            ],
+            [
+                "<body>\n\t<style>a {color: blue;}</style>\nactual content</body>",
+                "actual content"
             ],
             [
                 'Please click <a href="http://www.google.com">this</a> link',
@@ -104,13 +108,13 @@ class PlaintextServiceTest extends UnitTestCase
     /**
      * @return void
      * @test
-     * @covers ::removeHeadElement
+     * @covers ::removeInvisibleElements
      */
-    public function removeHeadElementReturnString()
+    public function removeInvisibleElementsReturnString()
     {
-        $content = '<b>abc</b><head>test</head>test';
+        $content = "<b>abc</b><head>\n\t<title>test</title>\n</head><style>\n\ta {color: blue;}\n</style>test<script>\n\talert('hello');\n</script>";
         $expectedResult = '<b>abc</b>test';
-        $result = $this->generalValidatorMock->_call('removeHeadElement', $content);
+        $result = $this->generalValidatorMock->_call('removeInvisibleElements', $content);
         $this->assertSame($expectedResult, $result);
     }
 


### PR DESCRIPTION
Hey Alex!

The current implementation of `In2code\Powermail\Domain\Service\Mail\PlaintextService->makePlain` does not account for multi line `<head>` tags (because of missing `s` modifier) nor for further invisible tags. That is especially important when you want to add style to your emails. Since the `<style>` tag should be within the `<body>` tag for extended email client support, it is not enough to remove the `<head>` tag.

What do you think?

Kind regards
Markus