### PR TITLE
Extendability of UploadAttributesViewHelper

### DIFF
--- a/Classes/ViewHelpers/Validation/UploadAttributesViewHelper.php
+++ b/Classes/ViewHelpers/Validation/UploadAttributesViewHelper.php
@@ -40,23 +40,30 @@ class UploadAttributesViewHelper extends AbstractValidationViewHelper
         if ($field->getMultiselectForField()) {
             $additionalAttributes['multiple'] = 'multiple';
         }
-        
+
         $filesize = $this->settings['misc']['file']['extension'];
         if (null !== $this->arguments['filesize']) {
         	$filesize = $this->arguments['filesize'];
        	}
-        $this->addFilesizeValidation($additionalAttributes, (int)$filesize);
-        
+        $this->addFilesizeValidation($additionalAttributes, $field, (int) $filesize);
+
         $extension = $this->settings['misc']['file']['extension'];
         if (null !== $this->arguments['extension']) {
-        	$extension = $this->arguments['extension';
+        	$extension = $this->arguments['extension'];
        	}
-       	$this->addExtensionValidation($additionalAttributes, $extension);
-       	
+       	$this->addExtensionValidation($additionalAttributes, $field, $extension);
+
         return $additionalAttributes;
     }
-    
-    protected function addFilesizeValidation(array &$additionalAttributes, int $filesize): void
+
+    /**
+     * Set attributes for filesize validation
+     * @param array &$additionalAttributes
+     * @param Field $field
+     * @param int   $filesize
+     * @return void
+     */
+    protected function addFilesizeValidation(array &$additionalAttributes, Field $field, int $filesize)
     {
         if ($this->isClientValidationEnabled()) {
             if (!empty($filesize)) {
@@ -65,10 +72,17 @@ class UploadAttributesViewHelper extends AbstractValidationViewHelper
                 $additionalAttributes['data-parsley-powermailfilesize-message'] =
                     LocalizationUtility::translate('validationerror_upload_size');
             }
-		}    
+		}
     }
-    
-    protected function addExtensionValidation(array &$additionalAttributes, string $extension): void
+
+    /**
+     * Set attributes for file extension validation
+     * @param array  &$additionalAttributes
+     * @param Field $field
+     * @param string $extension
+     */
+    protected function addExtensionValidation(array &$additionalAttributes, Field $field, string $extension)
+    {
         if (!empty($extension)) {
             $additionalAttributes['accept'] =
                 $this->getDottedListOfExtensions($extension);
@@ -81,7 +95,7 @@ class UploadAttributesViewHelper extends AbstractValidationViewHelper
             }
         }
     }
-    
+
 
     /**
      * Get extensions with dot as prefix

--- a/Classes/ViewHelpers/Validation/UploadAttributesViewHelper.php
+++ b/Classes/ViewHelpers/Validation/UploadAttributesViewHelper.php
@@ -20,6 +20,8 @@ class UploadAttributesViewHelper extends AbstractValidationViewHelper
         parent::initializeArguments();
         $this->registerArgument('field', Field::class, 'Field', true);
         $this->registerArgument('additionalAttributes', 'array', 'additionalAttributes', false, []);
+        $this->registerArgument('filesize', 'int', 'filesize', false, null);
+        $this->registerArgument('extension', 'string', 'extension', false, null);
     }
 
     /**
@@ -34,28 +36,52 @@ class UploadAttributesViewHelper extends AbstractValidationViewHelper
         $additionalAttributes = $this->arguments['additionalAttributes'];
 
         $this->addMandatoryAttributes($additionalAttributes, $field);
+
         if ($field->getMultiselectForField()) {
             $additionalAttributes['multiple'] = 'multiple';
         }
-        if (!empty($this->settings['misc']['file']['extension'])) {
-            $additionalAttributes['accept'] =
-                $this->getDottedListOfExtensions($this->settings['misc']['file']['extension']);
-        }
+        
+        $filesize = $this->settings['misc']['file']['extension'];
+        if (null !== $this->arguments['filesize']) {
+        	$filesize = $this->arguments['filesize'];
+       	}
+        $this->addFilesizeValidation($additionalAttributes, (int)$filesize);
+        
+        $extension = $this->settings['misc']['file']['extension'];
+        if (null !== $this->arguments['extension']) {
+        	$extension = $this->arguments['extension';
+       	}
+       	$this->addExtensionValidation($additionalAttributes, $extension);
+       	
+        return $additionalAttributes;
+    }
+    
+    protected function addFilesizeValidation(array &$additionalAttributes, int $filesize): void
+    {
         if ($this->isClientValidationEnabled()) {
-            if (!empty($this->settings['misc']['file']['size'])) {
+            if (!empty($filesize)) {
                 $additionalAttributes['data-parsley-powermailfilesize'] =
-                    (int)$this->settings['misc']['file']['size'] . ',' . $field->getMarker();
+                    $filesize . ',' . $field->getMarker();
                 $additionalAttributes['data-parsley-powermailfilesize-message'] =
                     LocalizationUtility::translate('validationerror_upload_size');
             }
-            if (!empty($this->settings['misc']['file']['extension'])) {
+		}    
+    }
+    
+    protected function addExtensionValidation(array &$additionalAttributes, string $extension): void
+        if (!empty($extension)) {
+            $additionalAttributes['accept'] =
+                $this->getDottedListOfExtensions($extension);
+        }
+        if ($this->isClientValidationEnabled()) {
+            if (!empty($extension)) {
                 $additionalAttributes['data-parsley-powermailfileextensions'] = $field->getMarker();
                 $additionalAttributes['data-parsley-powermailfileextensions-message'] =
                     LocalizationUtility::translate('validationerror_upload_extension');
             }
         }
-        return $additionalAttributes;
     }
+    
 
     /**
      * Get extensions with dot as prefix


### PR DESCRIPTION
With these modifications, the UploadAttributesViewHelper gets 2 new arguments:

* filesize - Maximum filesize
* extension - Allowed extensions

These fluid arguments override the TS Settings. This can be used in custom type partials, for example.