### PR TITLE
[BUGFIX] Remove log errors with frontend_editing

### DIFF
--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -170,7 +170,7 @@ class BackendUtility extends AbstractUtility
     public static function getPidFromBackendPage($returnUrl = '')
     {
         if (empty($returnUrl)) {
-            $returnUrl = GeneralUtility::_GP('returnUrl');
+            $returnUrl = GeneralUtility::_GP('returnUrl') ? GeneralUtility::_GP('returnUrl') : "";
         }
         $urlParts = parse_url($returnUrl);
         parse_str((string)$urlParts['query'], $queryParts);


### PR DESCRIPTION
When using frontend_editing 1.3.3 with Typo3 8.7.10 and PHP 7.2, loading a page with a powermail plugin in frontend_editing mode triggers the following error (provided headers are made inline editable) :
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: parse_url() expects parameter 1 to be string, null given | TypeError thrown in file /home/typo3/production/typo3conf/ext/powermail/Classes/Utility/BackendUtility.php in line 175. Requested URL: https://xxxx/typo3/index.php?ajaxID=%2Fajax%2Ffrontend-editing%2Feditor-configuration&ajaxToken=f812db1d247fa86e866e2a68fa436e398456df6d&page=7179&table=tt_content&uid=58276&field=header `
This doesn't really prevent using FE editing, but quickly fills the logs.