### PR TITLE
Updated spamshield documentation

### DIFF
--- a/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
@@ -628,6 +628,15 @@ Constants Overview
       text
    :Default:
       EXT:powermail/Resources/Private/Templates/Mail/SpamNotification.html
+      
+ - :Constants:
+      spamshield.senderEmail
+   :Description:
+      Spamshield Notifymail sender Email address: Define a specific Email address as sender of the notification Email
+   :Type:
+      text
+   :Default:
+      'powermail@' + the TYPO3 host (e.g. powermail@www.example.com)
 
  - :Constants:
       spamshield.logfileLocation


### PR DESCRIPTION
It took me a while to figure out why a customer system repeatedly tried to send e-mails with powermail@[customer domain]. Since allowed sender e-mail addresses need to be explicitly white-listed on this system bounce messages flooded the mail log. Browsing the code revealed that spamshield.senderEmail is available as settings option. I think it might be a good idea to add this option to the documentation.