### PR TITLE
Testing framework requires PHP < 7.2

### DIFF
--- a/Tests/Behavior/readme.md
+++ b/Tests/Behavior/readme.md
@@ -4,7 +4,8 @@
 
 * First of all, do a `composer update` in powermail root folder (currently this requires PHP php >=5.3 < 7.2)
 * You have to install a local TYPO3-instance (8.7) next and it should be available under `powermail.localhost.de`
-* A dump is available under http://powermail.in2code.ws/fileadmin/behat/powermail.sql.gz
+* Move (or symlink) the powermail-Folder into typo3conf/ext/ and activate the extension.
+* Them import the database dump from http://powermail.in2code.ws/fileadmin/behat/powermail.sql.gz
 
 ## Command line
 

--- a/Tests/Behavior/readme.md
+++ b/Tests/Behavior/readme.md
@@ -2,7 +2,7 @@
 
 ## Preperations
 
-* First of all, do a `composer update` in powermail root folder
+* First of all, do a `composer update` in powermail root folder (currently this requires PHP php >=5.3 < 7.2)
 * You have to install a local TYPO3-instance (8.7) next and it should be available under `powermail.localhost.de`
 * A dump is available under http://powermail.in2code.ws/fileadmin/behat/powermail.sql.gz
 


### PR DESCRIPTION
When running `composer update`, I get the following error:

nimut/testing-framework 1.1.9 requires php >=5.3 < 7.2 -> your PHP version (7.2.4) does not satisfy that requirement.

testing-framework has new major versions that allow 7.2 - can you please test them and update the composer.json?
Until then, the workaround is to use PHP 7.1 or lower.