### PR TITLE
Change display order of tables in backend list view

### DIFF
--- a/Configuration/TSConfig/WebList.typoscript
+++ b/Configuration/TSConfig/WebList.typoscript
@@ -1,0 +1,11 @@
+mod.web_list.tableDisplayOrder {
+  tx_powermail_domain_model_answer {
+    after = tx_powermail_domain_model_mail
+  }
+  tx_powermail_domain_model_page {
+    after = tx_powermail_domain_model_form
+  }
+  tx_powermail_domain_model_field {
+    after = tx_powermail_domain_model_page
+  }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -46,6 +46,13 @@ call_user_func(function () {
     );
 
     /**
+     * PageTSConfig for backend mod list
+     */
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:powermail/Configuration/TSConfig/WebList.typoscript">'
+    );
+    
+    /**
      * Hook to show PluginInformation under a tt_content element in page module of type powermail
      */
     $cmsLayout = 'cms/layout/class.tx_cms_layout.php';


### PR DESCRIPTION
## About the change
At the moment the tables in the list view of the backend are sorted alphabetically. A storage with forms, mails... looks like this: 
- Answers
- Fields
- Forms 
- Mails
- Pages

This PR changes the order of the tables to the following: 
- Mails
- Answers
- Forms
- Pages
- Fields

This is possible by using a feature of PageTSconf introduced in TYPO3 7.4 - [Feature #65550](https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.4/Feature-65550-MakeTableDisplayOrderConfigurableInListModule.html)

## Why the change

By using inline TCA the editor can create a form which contains pages which are containing fields. 
Reproducing this hierarchical structure in the list would make it easier to find the element you are looking for. 


Just a small change, but I found it to be quite a good improvement in the backend usability. Please correct me if I missed something. 