### PR TITLE
Add actions as css classes to powermail_frontend

### DIFF
--- a/Resources/Private/Templates/Output/Delete.html
+++ b/Resources/Private/Templates/Output/Delete.html
@@ -7,7 +7,7 @@ Render Delete Message
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
 	</f:alias>
 
-	<div class="powermail_frontend">
+	<div class="powermail_frontend delete">
 		<f:link.action action="list" pageUid="{listPid}" class="powermail_frontend_back">
 			<f:translate key="back">Go back</f:translate>
 		</f:link.action>

--- a/Resources/Private/Templates/Output/Edit.html
+++ b/Resources/Private/Templates/Output/Edit.html
@@ -11,7 +11,7 @@
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
 	</f:alias>
 
-	<div class="powermail_frontend">
+	<div class="powermail_frontend edit">
 		<f:if condition="{mail}">
 			<f:then>
 				<f:if condition="{vh:Condition.IsAllowedToEdit(settings:settings, mail:mail)}">

--- a/Resources/Private/Templates/Output/List.html
+++ b/Resources/Private/Templates/Output/List.html
@@ -11,7 +11,7 @@ Render Powermail_Frontend List View
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
 	</f:alias>
 
-	<div class="powermail_frontend">
+	<div class="powermail_frontend list">
 
 		<f:render partial="Output/Search" arguments="{_all}" />
 

--- a/Resources/Private/Templates/Output/Show.html
+++ b/Resources/Private/Templates/Output/Show.html
@@ -10,7 +10,7 @@ Render Powermail_Frontend Show View
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
 	</f:alias>
 
-	<div class="powermail_frontend">
+	<div class="powermail_frontend show">
 		<table class="table table-striped table-hover table-responsive">
 			<f:for each="{fields}" as="field">
 				<f:for each="{mail.answers}" as="answer">


### PR DESCRIPTION
For identifying in which view we are in, to be able to style it without overriding the template (I did it because of list/show, added the others for consistency)