### PR TITLE
[BUGFIX] Force string value on possible nullable return

### DIFF
--- a/Classes/ViewHelpers/Misc/GetFileWithPathViewHelper.php
+++ b/Classes/ViewHelpers/Misc/GetFileWithPathViewHelper.php
@@ -50,7 +50,7 @@ class GetFileWithPathViewHelper extends AbstractViewHelper
                     if ($thisStorage->hasFolder($subPath)) {
                         $folder = $thisStorage->getFolder($subPath);
                         $file = $thisStorage->getFileInFolder($fileName, $folder);
-                        return $file->getPublicUrl();
+                        return (string)$file->getPublicUrl();
                     }
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
When listing an upload that is not available via public url, the ViewHelper crashes on  forced ```:string``` return type in function.

![screen shot 2018-08-13 at 09 15 00](https://user-images.githubusercontent.com/2414665/44018464-2d2ac3b6-9edc-11e8-8cca-0c983fbb740f.png)

Typecasted the value to string, to return empty string instead of ```null```; 