### PR TITLE
Add db indices for the page and field tables

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -81,6 +81,7 @@ CREATE TABLE tx_powermail_domain_model_page (
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),
+	KEY parent_form (forms),
 	KEY t3ver_oid (t3ver_oid,t3ver_wsid),
 	KEY language (l10n_parent,sys_language_uid)
 );
@@ -145,6 +146,7 @@ CREATE TABLE tx_powermail_domain_model_field (
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),
+	KEY parent_page (pages),
 	KEY t3ver_oid (t3ver_oid,t3ver_wsid),
 	KEY language (l10n_parent,sys_language_uid)
 );


### PR DESCRIPTION
Without this patch powermail queries are popping up in mysql slow log.
e.g.
```
SELECT  tx_powermail_domain_model_page.* FROM tx_powermail_domain_model_page  WHERE tx_powermail_domain_model_page.forms = 104 AND tx_powermail_domain_model_page.deleted=0 AND tx_powermail_domain_model_page.t3ver_state<=0 AND tx_powermail_domain_model_page.pid<>-1 AND tx_powermail_domain_model_page.hidden=0 AND tx_powermail_domain_model_page.starttime<=1534415100 AND (tx_powermail_domain_model_page.endtime=0 OR tx_powermail_domain_model_page.endtime>1534415100) ORDER BY tx_powermail_domain_model_page.sorting ASC
```
or
```
SELECT  tx_powermail_domain_model_field.* FROM tx_powermail_domain_model_field  WHERE tx_powermail_domain_model_field.pages = 174 AND tx_powermail_domain_model_field.deleted=0 AND tx_powermail_domain_model_field.t3ver_state<=0 AND tx_powermail_domain_model_field.pid<>-1 AND tx_powermail_domain_model_field.hidden=0 AND tx_powermail_domain_model_field.starttime<=1534416060 AND (tx_powermail_domain_model_field.endtime=0 OR tx_powermail_domain_model_field.endtime>1534416060) ORDER BY tx_powermail_domain_model_field.sorting ASC
```