### PR TITLE
Add time converter

### DIFF
--- a/Classes/UserFunc/DateConverter.php
+++ b/Classes/UserFunc/DateConverter.php
@@ -77,6 +77,10 @@ class DateConverter
         $this->initialize($configuration);
         $this->createDateFromFormat();
         if ($this->getDate() !== null) {
+            // If a time only should be converted to a timestamp, convert to seconds manually to avoid offset issues
+            if(($this->getInputFormat() == 'H' || $this->getInputFormat() == 'H:i' || $this->getInputFormat() == 'H:i:s') && ($this->outputFormat == 'U')){
+                return $this->getDate()->format('H') * 3600 + $this->getDate()->format('i') * 60 + $this->getDate()->format('s');
+            }
             return $this->getDate()->format($this->getOutputFormat());
         }
         return '';

--- a/Classes/UserFunc/TimeConverter.php
+++ b/Classes/UserFunc/TimeConverter.php
@@ -1,0 +1,191 @@
+<?php
+declare (strict_types = 1);
+namespace In2code\Powermail\UserFunc;
+
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Class TimeConverter
+ */
+class TimeConverter
+{
+
+    /**
+     * @var ContentObjectRenderer
+     */
+    public $cObj;
+
+    /**
+     * UserFunc configuration TypoScript
+     *
+     * @var array
+     */
+    protected $configuration = [];
+
+    /**
+     * Value to convert
+     *
+     * @var string
+     */
+    protected $input = '';
+
+    /**
+     * input format
+     *
+     * @var string
+     */
+    protected $inputFormat = 'Y-m-d';
+
+    /**
+     * format to convert
+     *
+     * @var string
+     */
+    protected $outputFormat = 'd.m.Y';
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $date = null;
+
+    /**
+     * UserFunc method to convert a datestring from one format into another
+     *
+     * Example:
+     * # Convert 2015-12-31 into 1451516400
+     * lib.test = USER
+     * lib.test {
+     *        userFunc = In2code\Powermail\UserFunc\TimeConverter->convert
+     *        includeLibs = EXT:powermail/Classes/UserFunc/TimeConverter.php
+     *
+     *        input = TEXT
+     *        input.value = 2015-12-31
+     *
+     *        inputFormat = TEXT
+     *        inputFormat.value = Y-m-d
+     *
+     *        outputFormat = TEXT
+     *        outputFormat.value = U
+     * }
+     *
+     * @param string $content normally empty in userFuncs
+     * @param array $configuration TypoScript configuration from userFunc
+     * @return string
+     */
+    public function convert($content = '', $configuration = [])
+    {
+        $this->initialize($configuration);
+        $this->createDateFromFormat();
+        if ($this->getDate() !== null) {
+            return $this->getDate()->format('H') * 3600 + $this->getDate()->format('i') * 60 + $this->getDate()->format('s');
+        }
+        return '';
+    }
+
+    /**
+     * Create date from format
+     *
+     * @return void
+     */
+    protected function createDateFromFormat()
+    {
+        $date = \DateTime::createFromFormat($this->getInputFormat(), $this->getInput());
+        if ($date !== false) {
+            $this->setDate($date);
+        }
+    }
+
+    /**
+     * Init function
+     *
+     * @param array $configuration
+     * @return void
+     */
+    protected function initialize($configuration)
+    {
+        $this->configuration = $configuration;
+        $this->setInput()->setInputFormat()->setOutputFormat();
+    }
+
+    /**
+     * @return TimeConverter
+     */
+    protected function setInput()
+    {
+        $input = $this->cObj->cObjGetSingle($this->configuration['input'], $this->configuration['input.']);
+        if (!empty($input)) {
+            $this->input = $input;
+        }
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * @return TimeConverter
+     */
+    protected function setInputFormat()
+    {
+        $inputFormat = $this->cObj->cObjGetSingle(
+            $this->configuration['inputFormat'],
+            $this->configuration['inputFormat.']
+        );
+        if (!empty($inputFormat)) {
+            $this->inputFormat = $inputFormat;
+        }
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInputFormat()
+    {
+        return $this->inputFormat;
+    }
+
+    /**
+     * @return TimeConverter
+     */
+    protected function setOutputFormat()
+    {
+        $outputFormat = $this->cObj->cObjGetSingle(
+            $this->configuration['outputFormat'],
+            $this->configuration['outputFormat.']
+        );
+        if (!empty($outputFormat)) {
+            $this->outputFormat = $outputFormat;
+        }
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutputFormat()
+    {
+        return $this->outputFormat;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate(\DateTime $date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+}

--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -273,6 +273,9 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
              * LENGTH
              *
              * Note: Field validation_configuration for editors viewable
+             * html5 example:
+             *        <input type="text" maxlength="10" />
+             *        <textarea maxlength="500" />
              * javascript example:
              *        <input type="text" data-parsley-length="[6, 10]" />
              */
@@ -285,8 +288,12 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
                     $values[1] = (int)$values[0];
                     $values[0] = 1;
                 }
-                if ($this->isClientValidationEnabled()) {
-                    $additionalAttributes['data-parsley-length'] = '[' . implode(', ', $values) . ']';
+                if ($this->isNativeValidationEnabled()) {
+                    $additionalAttributes['maxlength'] = $values[1];
+                } else {
+                    if ($this->isClientValidationEnabled()) {
+                        $additionalAttributes['data-parsley-length'] = '[' . implode(', ', $values) . ']';
+                    }
                 }
                 break;
 


### PR DESCRIPTION
If a field is H:i, it can't be passed through the Dateconverter, because the timezone will fail for sure. So I added a TimeConverter, or, as an alternative, simply a variant for DateConverter.

This is not a valid PR, but you can see what I have in mind. No worries if you don't want to go that way, I can do it in a custom function as well.

