### PR TITLE
[BUGFIX] Cast value to string before returning it

### DIFF
--- a/Classes/ViewHelpers/Misc/ManipulateValueWithTypoScriptViewHelper.php
+++ b/Classes/ViewHelpers/Misc/ManipulateValueWithTypoScriptViewHelper.php
@@ -66,7 +66,7 @@ class ManipulateValueWithTypoScriptViewHelper extends AbstractViewHelper
                 );
             }
         }
-        return $value;
+        return (string)$value;
     }
 
     /**


### PR DESCRIPTION
The render function of ManipulateValueWithTypoScriptViewHelper
must return a string value. If a numeric value is used a wrong type
is returned and an exception is thrown. This happens for example
if a checkbox with an integer value is used like
[x] "confirmed legal stuff" = 1