### PR TITLE
Remove usage of disableRemoveXss

### DIFF
--- a/Resources/Private/Partials/Form/Html.html
+++ b/Resources/Private/Partials/Form/Html.html
@@ -8,7 +8,7 @@
 
 <div id="powermail_fieldwrap_{field.uid}" class="powermail_fieldwrap powermail_fieldwrap_html powermail_fieldwrap_{field.uid} {field.css}">
 	<span id="powermail_field_{field.marker}">
-		<f:if condition="{settings.misc.disableRemoveXss}">
+		<f:if condition="{settings.misc.htmlForHtmlFields}">
 			<f:then>
 				<f:format.raw>{field.text}</f:format.raw>
 			</f:then>


### PR DESCRIPTION
In the changes for v2.25.3 was one usage of disableRemoveXss forgotten to remove. This leads to the problem that HTML output does not work with version 2.25.3