### PR TITLE
Fix default value of randomizeFileName

### DIFF
--- a/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
@@ -538,7 +538,7 @@ Constants Overview
    :Type:
       bool
    :Default:
-      0
+      1
 
  - :Constants:
       misc.forceJavaScriptDatePicker


### PR DESCRIPTION
The default value of misc.randomizeFileName in typoscript constants is 1, not 0.