### PR TITLE
[BUGFIX] Markers in non-default language fields

### DIFF
--- a/Classes/Domain/Model/Field.php
+++ b/Classes/Domain/Model/Field.php
@@ -141,6 +141,11 @@ class Field extends AbstractEntity
     protected $sorting = 0;
 
     /**
+     * @var integer
+     */
+    protected $l10nParent = 0;
+
+    /**
      * @var \In2code\Powermail\Domain\Model\Page
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      * @extensionScannerIgnoreLine Still needed for TYPO3 8.7
@@ -818,7 +823,8 @@ class Field extends AbstractEntity
      */
     public function isLocalized()
     {
-        return $this->_getProperty('_languageUid') > 0;
+        return $this->_getProperty('_languageUid') > 0 &&
+            $this->_getProperty('l10nParent') > 0;
     }
 
     /**

--- a/Classes/Hook/CreateMarker.php
+++ b/Classes/Hook/CreateMarker.php
@@ -154,7 +154,8 @@ class CreateMarker
      */
     protected function cleanMarkersInLocalizedFields()
     {
-        if (!empty($this->properties['sys_language_uid']) && $this->properties['sys_language_uid'] > 0) {
+        if (!empty($this->properties['sys_language_uid']) && $this->properties['sys_language_uid'] > 0 &&
+            !empty($this->properties['l10n_parent']) && $this->properties['l10n_parent'] > 0) {
             $this->properties['marker'] = '';
         }
     }


### PR DESCRIPTION
Assume a field is localized only when its sys_language_uid and l10n_parent are greater than 0. Closes #329.