### PR TITLE
Add equal sign to captcha

### DIFF
--- a/Classes/Domain/Service/CalculatingCaptchaService.php
+++ b/Classes/Domain/Service/CalculatingCaptchaService.php
@@ -244,7 +244,7 @@ class CalculatingCaptchaService
 
         return [
             'result' => $result,
-            'string' => $number1 . ' ' . $operator . ' ' . $number2
+            'string' => $number1 . ' ' . $operator . ' ' . $number2 . ' ='
         ];
     }
 


### PR DESCRIPTION
Add a equal sign to the captcha image so that people know they have to calculate the result and dont have to write the captcha text into the input field.