### PR TITLE
[FEATURE] Abort the Email-Send process by signal

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -126,8 +126,16 @@ class SendMailService
         $message = $this->addPlainBody($message, $email);
         $message = $this->addSenderHeader($message);
 
+        $email['send'] = true;
         $signalArguments = [$message, &$email, $this];
         $this->signalDispatch(__CLASS__, 'sendTemplateEmailBeforeSend', $signalArguments);
+        if (!$email['send']) {
+            if ($this->settings['debug']['mail']) {
+                $logger = ObjectUtility::getLogger(__CLASS__);
+                $logger->info('Mail was not sent: the signal has aborted sending. Email array after signal execution:', [$email]);
+            }
+            return false;
+        }
 
         $message->send();
         $this->updateMail($email);

--- a/Documentation/ForAdministrators/BestPractice/Debug/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/Debug/Index.rst
@@ -5,10 +5,11 @@
 Debug Powermail
 ---------------
 
-With TypoScript it's possible to enable some Devlog Output,
+With TypoScript it's possible to enable some logging Output,
 which could help you to fix problems or a misconfiguration.
 
-You need an additional extension to show the debug output (e.g. "devlog").
+The logging output will not be saved by default. You need to enable it (see example below).
+https://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Logging/Index.html
 
 Comprehensive Example
 """""""""""""""""""""
@@ -24,6 +25,18 @@ Comprehensive Example
 			spamshield = 0
 		}
 	}
+
+.. code-block:: php
+   $GLOBALS['TYPO3_CONF_VARS']['LOG']['In2code']['Powermail']['writerConfiguration'] = [
+      // configuration for WARNING severity, including all
+      // levels with higher severity (ERROR, CRITICAL, EMERGENCY)
+      \TYPO3\CMS\Core\Log\LogLevel::DEBUG => [
+      // add a SyslogWriter
+         'TYPO3\\CMS\\Core\\Log\\Writer\\FileWriter' => [
+            'logFile' => 'typo3temp/logs/powermail.log',
+         ],
+      ],
+   ];
 
 
 Configuration


### PR DESCRIPTION
Currently it is not possible to hook into the sending process and prevent sending the email altogether.

I am using this feature to decide in the hook based on the saved Answers whether the email should be sent now - or later (similar to the optinConfirm-Flow). Another Usecase would be to dynamically decide whether the receiver template email should be sent or not.

Also, I have updated the logging documentation.