### PR TITLE
[FEATURE] Allow prepending the original filename on randomizing

### DIFF
--- a/Classes/Domain/Service/UploadService.php
+++ b/Classes/Domain/Service/UploadService.php
@@ -240,7 +240,7 @@ class UploadService implements SingletonInterface
             if (!$file->isUploaded()) {
                 $fileName = $file->getNewName();
                 if ($this->isRandomizeFileNameConfigured()) {
-                    $fileName = $this->randomizeFileName($file->getNewName());
+                    $fileName = $this->randomizeFileName($file->getNewName(), $this->isPrependOriginalFileNameConfigured());
                     $file->renameName($fileName);
                 }
                 for ($i = 1; $this->isNotUniqueFilename($file); $i++) {
@@ -285,12 +285,20 @@ class UploadService implements SingletonInterface
 
     /**
      * @param string $filename
+     * @param bool $prependOriginalFileName
+     *
      * @return string
      */
-    protected function randomizeFileName($filename)
+    protected function randomizeFileName($filename, $prependOriginalFileName = false)
     {
         $fileInfo = pathinfo($filename);
-        return StringUtility::getRandomString(32, false) . '.' . $fileInfo['extension'];
+        $randomizedFileName = '';
+        if ($prependOriginalFileName) {
+            $randomizedFileName .= $fileInfo['filename'] . '-';
+        }
+        $randomizedFileName .= StringUtility::getRandomString(32, false);
+        $randomizedFileName .= '.' . $fileInfo['extension'];
+        return $randomizedFileName;
     }
 
     /**
@@ -328,6 +336,14 @@ class UploadService implements SingletonInterface
     protected function isRandomizeFileNameConfigured()
     {
         return $this->settings['misc']['file']['randomizeFileName'] === '1';
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isPrependOriginalFileNameConfigured()
+    {
+        return $this->settings['misc']['file']['randomizePrependOriginalFileName'] === '1';
     }
 
     /**

--- a/Configuration/TypoScript/Main/constants.txt
+++ b/Configuration/TypoScript/Main/constants.txt
@@ -219,6 +219,9 @@ plugin.tx_powermail {
 			# cat=powermail_additional//0840; type=boolean; label= Randomized Filenames: Uploaded filenames can be randomized to respect data privacy
 			randomizeFileName = 1
 
+			# cat=powermail_additional//0840; type=boolean; label= Prepend original file name: Prepend original file name to randomized file name if randomizeFileName is enabled
+			randomizePrependOriginalFileName = 0
+
 			# cat=powermail_additional//0845; type=boolean; label= Force JavaScript Datepicker: Per default html5 Date or Datetime format is used. If you don't want to use it and want to have the same datepicker all over all browsers, you can enable this feature
 			forceJavaScriptDatePicker = 0
 

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -543,6 +543,7 @@ plugin.tx_powermail {
 					size = {$plugin.tx_powermail.settings.misc.uploadSize}
 					extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
 					randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+					randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
 				}
 
 				datepicker {

--- a/Configuration/TypoScript/Powermail_Frontend/setup.txt
+++ b/Configuration/TypoScript/Powermail_Frontend/setup.txt
@@ -33,6 +33,7 @@ plugin.tx_powermail {
 					size = {$plugin.tx_powermail.settings.misc.uploadSize}
 					extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
 					randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+					randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
 				}
 			}
 

--- a/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/MainTypoScript/Index.rst
@@ -1396,6 +1396,7 @@ Setup
                         size = {$plugin.tx_powermail.settings.misc.uploadSize}
                         extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
                         randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+                        randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
                     }
 
                     datepicker {


### PR DESCRIPTION
Currently, on randomizing the file name, the file name itself gets lost and replaced by a 32 character string. This way, the recipient may lose overview about multiple attachments.

To ensure both "safety" and information, a new configuration `randomizePrependOriginalFileName` is introduced. If set, the random string is prepended with the original file name.