### PR TITLE
Ensure <a> tags are rendered with absolute URLs

### DIFF
--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -974,6 +974,7 @@ plugin.tx_powermail {
 # ParseFunc Configuration for using FAL links in receiver and sender mail
 lib.parseFunc_powermail < lib.parseFunc_RTE
 lib.parseFunc_powermail.tags.link.typolink.forceAbsoluteUrl = 1
+lib.parseFunc_powermail.tags.a.typolink.forceAbsoluteUrl = 1
 
 
 ############################


### PR DESCRIPTION
Since links are not <link> tags but proper <a> tags those tags need to be absolute-ified as well.

Related: #114 