### PR TITLE
[FEATURE] targetUrl may now be a ts object, too

### DIFF
--- a/Classes/Finisher/SendParametersFinisher.php
+++ b/Classes/Finisher/SendParametersFinisher.php
@@ -90,8 +90,13 @@ class SendParametersFinisher extends AbstractFinisher implements FinisherInterfa
      */
     protected function getCurlSettings()
     {
+        if (isset($this->configuration['targetUrl.'])) {
+            $targetUrl = $this->contentObject->cObjGetSingle($this->configuration['targetUrl'], $this->configuration['targetUrl.']);
+        } else {
+            $targetUrl = $this->configuration['targetUrl'];
+        }
         return [
-            'url' => $this->configuration['targetUrl'],
+            'url' => $targetUrl,
             'username' => $this->configuration['username'],
             'password' => $this->configuration['password'],
             'params' => $this->getValues()

--- a/Documentation/ForAdministrators/BestPractice/SendingValuesToThirdPartySoftware/Index.rst
+++ b/Documentation/ForAdministrators/BestPractice/SendingValuesToThirdPartySoftware/Index.rst
@@ -26,6 +26,10 @@ See TypoScript Settings example:
 
 				# Target URL for POST values (like http://www.target.com/target.php)
 				targetUrl = http://eloqua.com/e/f.aspx
+				
+				# target url may just be a static string as well as a TS object like this, so wrap can be applied, .data or .field could be used
+				# targetUrl = TEXT
+				# targetUrl.value = foobar
 
 				# Basic Auth Protection - leave empty if Target is not protected
 				username =
@@ -62,6 +66,16 @@ See TypoScript Settings example:
 		}
 	}
 
+**Use case:** Editor wants to have the option to provide custom targets for a certain form, but use a given default for everything else.
+
+**Solution:** Just add a hidden field to your form, for instance "custom_url". Provide your default target url as string as before, but add some lines of TS code to overwrite it, if the field is set in the form:
+
+.. code-block:: text
+
+	[globalString = GP:tx_powermail_pi1|field|custom_url = /.+/]
+		plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl = TEXT
+		plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl.field = custom_url
+	[global]
 
 Own implementation
 ------------------


### PR DESCRIPTION
So it is now possible to just provide a url as string:
```
plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl = https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8
```
So the change is backward compatible. The new feature is, that it is now possible to use cObjSingle as well:

```
plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl = TEXT
plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl.field = custom_url
```

Use case is, that the customer/editor can now add a hidden field to the form where a certain url for a specific form can be added. If set, this will be used, else, the default config value will:

```
[globalString = GP:tx_powermail_pi1|field|custom_url = /.+/]
	plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl = TEXT
    plugin.tx_powermail.settings.setup.marketing.sendPost.targetUrl.field = custom_url
[global]
```