### PR TITLE
Add signal optinConfirmActionAfterPersist

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -296,6 +296,7 @@ class FormController extends AbstractController
                 $mail->setHidden(false);
                 $this->mailRepository->update($mail);
                 $this->persistenceManager->persistAll();
+                $this->signalDispatch(__CLASS__, __FUNCTION__ . 'AfterPersist', [$mail, $hash, $this]);
 
                 $this->forward('create', null, null, ['mail' => $mail, 'hash' => $hash]);
             }


### PR DESCRIPTION
Would be nice if you would add this signal so that one can invoke another process after optinMail has been confirmed and persisted.