### PR TITLE
[BUGFIX] UploadValidation hangs up when using double Opt-In

### DIFF
--- a/Classes/Domain/Validator/UploadValidator.php
+++ b/Classes/Domain/Validator/UploadValidator.php
@@ -79,8 +79,20 @@ class UploadValidator extends AbstractValidator
     {
         $arguments = GeneralUtility::_GP('tx_powermail_pi1');
         $formRepository = ObjectUtility::getObjectManager()->get(FormRepository::class);
-        /** @var Form $form */
-        $form = $formRepository->findByUid((int)$arguments['mail']['form']);
+
+        if( gettype($arguments['mail']) === "string" ){
+
+            $mailRepository = ObjectUtility::getObjectManager()->get(MailRepository::class);
+            /** @var Mail $mail */
+            $mail = $mailRepository->findByUid((int)$arguments['mail']);
+            /** @var Form $form */
+            $form = $formRepository->findByUid((int)$mail->getForm()->getUid());
+        }
+        else {
+            /** @var Form $form */
+            $form = $formRepository->findByUid((int)$arguments['mail']['form']);
+        }
+        
         return $form->hasUploadField();
     }
 


### PR DESCRIPTION
When using a fileupload in a form with double opt-in the uploadvalidator can
not directly access the form (mail is not an array as when the form is actually sent,
it is a string with the mail uid instead).

So a workaround is to get the form from the mail uid that is delivered within the confirmation link of tha double opt-in process.