### PR TITLE
[FEATURE] Use the new documentation rendering process

### DIFF
--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -1,17 +1,31 @@
-
-
 .. ==================================================
 .. FOR YOUR INFORMATION
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
+.. ---------
+.. textroles
+.. ---------
 
+.. role:: aspect (emphasis)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: rst(code)
+.. role:: sep (strong)
+.. role:: typoscript(code)
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
+.. role:: ts(typoscript)
+   :class: typoscript
+
+.. role:: yaml(code)
+
+.. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks are php
+
+.. highlight:: php

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,27 @@
+# Sphinx setup file
+#
+# Template see https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/DirectoryFilenames.html#example
+
+[general]
+project = powermail
+release = 7.3.1
+copyright = since 2006 by Alexander Kellner
+
+[html_theme_options]
+github_branch = develop
+github_repository = einpraegsam/powermail
+
+project_contact      = https://github.com/einpraegsam/powermail
+project_discussions  =
+project_home         = https://github.com/einpraegsam/powermail
+project_issues       = https://github.com/einpraegsam/powermail/issues
+project_repository   = https://github.com/einpraegsam/powermail
+
+[intersphinx_mapping]
+t3install     = https://docs.typo3.org/m/typo3/guide-installation/master/en-us/
+t3tca         = https://docs.typo3.org/m/typo3/reference-tca/master/en-us/
+t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
+t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
+
+[extlinks]
+issue = https://github.com/einpraegsam/powermail/issues/%s | Issue #

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
-      "web-dir": ".Build/Web"
+      "web-dir": ".Build/Web",
+      "extension-key": "powermail"
     }
   }
 }


### PR DESCRIPTION
The generation of rst files on docs.typo3.org changed. Theses changes
are necessary to make the work.

Additionally there are two more steps to do: 

* setup a new webook
* contact the documentation team for a redirect

More information on these two steps:

https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocForExtension/Migrate.html