### PR TITLE
Bugfix: Search for links in string answers only

### DIFF
--- a/Classes/Domain/Validator/SpamShield/LinkMethod.php
+++ b/Classes/Domain/Validator/SpamShield/LinkMethod.php
@@ -17,7 +17,7 @@ class LinkMethod extends AbstractMethod
     {
         $linkAmount = 0;
         foreach ($this->mail->getAnswers() as $answer) {
-            if (is_array($answer->getValue())) {
+            if (!is_string($answer->getValue())) {
                 continue;
             }
             preg_match_all('@http://|https://|ftp://@', $answer->getValue(), $result);


### PR DESCRIPTION
Fixes: TypeError: preg_match_all() expects parameter 2 to be string, boolean given
typo3conf/ext/powermail/Classes/Domain/Validator/SpamShield/LinkMethod.php in preg_match_all