### PR TITLE
[TASK] Hide honeypot field from screenreaders 

### DIFF
--- a/Resources/Private/Partials/Misc/HoneyPod.html
+++ b/Resources/Private/Partials/Misc/HoneyPod.html
@@ -8,6 +8,8 @@
 		<f:form.textfield
 				name="field[__hp]"
 				value=""
-				id="powermail_hp_{form.uid}" />
+				id="powermail_hp_{form.uid}"
+				tabindex="-1"
+				additionalAttributes="{autocomplete: 'powermail-hp-{form.uid}', aria-hidden: 'true'}" />
 	</div>
 </f:if>

--- a/Resources/Private/Partials/Misc/HoneyPod.html
+++ b/Resources/Private/Partials/Misc/HoneyPod.html
@@ -8,7 +8,6 @@
 		<f:form.textfield
 				name="field[__hp]"
 				value=""
-				id="powermail_hp_{form.uid}"
-				additionalAttributes="{autocomplete: 'new-powermail-hp'}" />
+				id="powermail_hp_{form.uid}" />
 	</div>
 </f:if>

--- a/Resources/Private/Partials/Misc/HoneyPod.html
+++ b/Resources/Private/Partials/Misc/HoneyPod.html
@@ -10,6 +10,6 @@
 				value=""
 				id="powermail_hp_{form.uid}"
 				tabindex="-1"
-				additionalAttributes="{autocomplete: 'powermail-hp-{form.uid}', aria-hidden: 'true'}" />
+				additionalAttributes="{autocomplete: 'new-powermail-hp-{form.uid}', aria-hidden: 'true'}" />
 	</div>
 </f:if>


### PR DESCRIPTION
The configured value `new-powermail-hp` for the autocomplete attribute is invalid and fails in the accessibility check provided by accessibilityinsights.io

AFAIK, valid values for autofill are:
* https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute
* https://www.w3.org/TR/WCAG21/#input-purposes