### PR TITLE
[TASK] Fix minor syntax in docs and locallang

### DIFF
--- a/Documentation/ForAdministrators/PowermailFrontend/Index.rst
+++ b/Documentation/ForAdministrators/PowermailFrontend/Index.rst
@@ -56,7 +56,7 @@ Plugin Settings
    :Description:
       Select a page with mails (optionsl)
    :Explanation:
-      Only mails which are stored in the given page are shown in the frontent (optional setting).
+      Only mails which are stored in the given page are shown in the frontend (optional setting).
    :Tab:
       Main Settings
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -27,7 +27,7 @@ Some basic points:
   values in the frontend again (Pi2).
 
 - Powermail send one or more mails to a static receiver or to dynamic receivers or
-  to a whole Frontent-User Group.
+  to a whole Frontend-User Group.
 
 - Different HTML-Templates (Fluid) and RTE fields in backend for all
   needed views.

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -70,7 +70,7 @@
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_mail.feuser">
 				<source>FE_User</source>
-				<target state="translated">Frontent-Benutzer</target>
+				<target state="translated">Frontend-Benutzer</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_mail.spam_factor">
 				<source>Spam Factor</source>
@@ -437,7 +437,7 @@
 				<target state="translated">Über TypoScript erstellen (z.B. lib.fieldvalues)</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.feuser_value">
-				<source>Value from logged in Frontent User</source>
+				<source>Value from logged in Frontend User</source>
 				<target state="translated">Aus Frontend-Benutzer-Datenbank</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.feuser_value.name">

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -329,7 +329,7 @@
 				<source>Create from TypoScript (e.g. lib.fieldvalues)</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.feuser_value">
-				<source>Value from logged in Frontent User</source>
+				<source>Value from logged in Frontend User</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.feuser_value.name">
 				<source>Name</source>

--- a/Resources/Private/Partials/Form/Field/Country.html
+++ b/Resources/Private/Partials/Form/Field/Country.html
@@ -2,7 +2,7 @@
 
 		<f:comment>
 			{vh:Form.Countries()} will try to get the country list from the extension static_info_tables (and _de, _fr etc...)
-			If static_info_tables is not installed, a static list of countries and the ISO3 code will be shown in frontent
+			If static_info_tables is not installed, a static list of countries and the ISO3 code will be shown in frontend
 			If you want to change sorting, Value or Label, please install static_info_tables
 		</f:comment>
 


### PR DESCRIPTION
locallang_db value for tx_powermail_domain_model_field.feuser_value
may also be adopted on translation server