### PR TITLE
[BUGFIX] Let global "unique" validator look into disabled mails

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -139,6 +139,7 @@ class MailRepository extends AbstractRepository
     public function findByMarkerValueForm(string $marker, string $value, Form $form, int $pageUid): QueryResultInterface
     {
         $query = $this->createQuery();
+        $query->getQuerySettings()->setIgnoreEnableFields(true);
         $fieldRepository = $this->objectManager->get(FieldRepository::class);
         $and = [
             $query->equals('answers.field', $fieldRepository->findByMarkerAndForm($marker, $form->getUid())),


### PR DESCRIPTION
When activating the "double opt-in" plugin setting,
new mail records are disabled until confirmed.
The uniqueness check failed in this case because only enabled mails
were taken into account.

Resolves: https://github.com/einpraegsam/powermail/issues/509