### PR TITLE
[Bugfix] TYPO3 10.4 Error on submit if logged in as FE user

### DIFF
--- a/Classes/Utility/FrontendUtility.php
+++ b/Classes/Utility/FrontendUtility.php
@@ -168,7 +168,7 @@ class FrontendUtility
     {
         $tsfe = ObjectUtility::getTyposcriptFrontendController();
         if (!empty($tsfe->fe_user->user[$propertyName])) {
-            return (string) $tsfe->fe_user->user[$propertyName];
+            return (string)$tsfe->fe_user->user[$propertyName];
         }
         return '';
     }

--- a/Classes/Utility/FrontendUtility.php
+++ b/Classes/Utility/FrontendUtility.php
@@ -168,7 +168,7 @@ class FrontendUtility
     {
         $tsfe = ObjectUtility::getTyposcriptFrontendController();
         if (!empty($tsfe->fe_user->user[$propertyName])) {
-            return $tsfe->fe_user->user[$propertyName];
+            return (string) $tsfe->fe_user->user[$propertyName];
         }
         return '';
     }

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+return [
+    \In2code\Powermail\Domain\Model\User::class => [
+        'tableName' => 'fe_users'
+    ],
+    \In2code\Powermail\Domain\Model\UserGroup::class => [
+        'tableName' => 'fe_groups'
+    ]
+];

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,21 +1,3 @@
-config.tx_extbase {
-	persistence {
-		classes {
-			In2code\Powermail\Domain\Model\User {
-				mapping {
-					tableName = fe_users
-				}
-			}
-			In2code\Powermail\Domain\Model\UserGroup {
-				mapping {
-					tableName = fe_groups
-				}
-			}
-		}
-	}
-}
-
-
 #################
 # Backend Module
 #################


### PR DESCRIPTION
We're upgrading a TYPO3 project and we came across an error on submitting a powermail form while the user is logged in as an FE user. 

1.) there seems to be a migration missing of "config.tx_extbase.persistence".
See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-87623-ReplaceConfigpersistenceclassesTyposcriptConfiguration.html for more details. 

2.) getPropertyFromLoggedInFrontendUser() in FrontendUtility.php has a type declaration for the return value: It must be a string. But a uid is no string... I'm fixing this problem with a cast of the result. 