### PR TITLE
[TASK] Lower severity for logger

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -445,7 +445,7 @@ class FormController extends AbstractController
         $arguments = $this->request->getArguments();
         if (empty($arguments['mail'])) {
             $logger = ObjectUtility::getLogger(__CLASS__);
-            $logger->alert('Redirect (mail empty)', $arguments);
+            $logger->warning('Redirect (mail empty)', $arguments);
             $this->forward('form');
         }
     }
@@ -464,7 +464,7 @@ class FormController extends AbstractController
             $formsToContent = GeneralUtility::intExplode(',', $this->settings['main']['form']);
             if (!in_array($mail->getForm()->getUid(), $formsToContent)) {
                 $logger = ObjectUtility::getLogger(__CLASS__);
-                $logger->alert('Redirect (optin)', [$formsToContent, (array)$mail]);
+                $logger->warning('Redirect (optin)', [$formsToContent, (array)$mail]);
                 $this->forward('form');
             }
         }

--- a/Classes/Finisher/SendParametersFinisher.php
+++ b/Classes/Finisher/SendParametersFinisher.php
@@ -79,7 +79,7 @@ class SendParametersFinisher extends AbstractFinisher implements FinisherInterfa
     {
         if ($this->configuration['debug']) {
             $logger = ObjectUtility::getLogger(__CLASS__);
-            $logger->alert('SendPost Values', $this->getCurlSettings());
+            $logger->info('SendPost Values', $this->getCurlSettings());
         }
     }
 


### PR DESCRIPTION
As an expected behaviour is caught, the logger should not
output "Alert: action must be taken immediately". Therefor
the severity of the message is lowered to warning.

Related: #487