### PR TITLE
[BUGFIX] Fix template ordering by respect the numeric template index

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -34,6 +34,7 @@ class TemplateUtility extends AbstractUtility
         );
         if (!empty($extbaseConfig['view'][$part . 'RootPaths'])) {
             $templatePaths = $extbaseConfig['view'][$part . 'RootPaths'];
+            ksort($templatePaths, SORT_NUMERIC);
             $templatePaths = array_values($templatePaths);
         }
         if (empty($templatePaths)) {


### PR DESCRIPTION
**The Problem / Issue / Bug:**
In a project with multiple template paths, the paths are not sorted numerically. As a result, the paths are processed in the wrong order according to possible templates and individualization is not possible.

**How this PR Solves The Problem:**
With this bugfix the template paths are sorted according to the numerical value, which was defined via TypoScript.

**Manual Testing Instructions:**
1. Add an additional template path in TypoScript (via the constants)
2. Outsource the template "/Templates/Form/Form.html" in the defined path
3. Change the template, e.g. by adding static text

**Result:**
Without this bugfix, the default template (Form.html) from EXT:powermail is always used. With this bugfix the modified template is used.

**Tested version:**
* powermail 7.4.0
* TYPO3 9.5.15

**Related Issue Link(s):**
* #459 (Wrong Template order)
* #460 (MR for Wrong Template order)