### PR TITLE
[BUGFIX] Fix condition syntax for powermail_frontend

### DIFF
--- a/Configuration/TypoScript/Powermail_Frontend/setup.typoscript
+++ b/Configuration/TypoScript/Powermail_Frontend/setup.typoscript
@@ -94,7 +94,7 @@ powermail_frontend_rss {
 
 	10 < styles.content.get
 }
-[getTSFE().type == 31311] || [getTSFE().type == 31312] || [getTSFE().type == 31319]
+[getTSFE().type == 31311 || getTSFE().type == 31312 || getTSFE().type == 31319]
 	# we don't want the wrapper div in our export files
 	tt_content.stdWrap.innerWrap >
 [end]


### PR DESCRIPTION
The symfony conditions do not seperate single conditions with square
brackets. They only have a square bracket at the beginning and the
end.

Fixes: #554