### PR TITLE
[BUGFIX] Check if uid is empty for plugin preview

### DIFF
--- a/Classes/Hook/PluginPreview.php
+++ b/Classes/Hook/PluginPreview.php
@@ -158,6 +158,9 @@ class PluginPreview implements PageLayoutViewDrawItemHookInterface
     protected function getFormTitleByUid(int $uid): string
     {
         $uid = $this->getLocalizedFormUid($uid, $this->getSysLanguageUid());
+        if ($uid === 0) {
+            return '';
+        }
         $row = BackendUtilityCore::getRecord(
             Form::TABLE_NAME,
             $uid,


### PR DESCRIPTION
If the powermail plugin is used via IRRE in e.g. EXT:news. the flexform
is not yet defined and therefore the backend breaks because of strict
return type.

As a solution check the ID before and return an empty string.