### PR TITLE
Add missing TCA language label for tx_powermail_domain_model_mail

### DIFF
--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="tabs.access" resname="tabs.access">
 				<source>Access</source>
 			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_mail" resname="tx_powermail_domain_model_mail">
+				<source>Mails</source>
+			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_mail.palette1" resname="tx_powermail_domain_model_mail.palette1">
 				<source>Sender</source>
 			</trans-unit>


### PR DESCRIPTION
Added a missing language label for the `tx_powermail_domain_model_mail` table where the list module was just showing the table name and in the add record wizard the Mails label was missing