### PR TITLE
[TASK] Harden TemplateUtility::fluidParseString()

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -163,6 +163,6 @@ class TemplateUtility
         $standaloneView = ObjectUtility::getObjectManager()->get(StandaloneView::class);
         $standaloneView->setTemplateSource($string);
         $standaloneView->assignMultiple($variables);
-        return $standaloneView->render();
+        return $standaloneView->render() ?? '';
     }
 }


### PR DESCRIPTION
Ensures the function will always return a string.

When the passed variable `$string` is a non existing fluid variable (e.g. `{foo}`), then `$standaloneView->render()` will return `null`. 

Possible Fluid core issue.