### PR TITLE
 [FEATURE] Allow prepending the original filename on randomizing the …

### DIFF
--- a/Classes/Domain/Service/UploadService.php
+++ b/Classes/Domain/Service/UploadService.php
@@ -260,7 +260,7 @@ class UploadService implements SingletonInterface
             if (!$file->isUploaded()) {
                 $fileName = $file->getNewName();
                 if ($this->isRandomizeFileNameConfigured()) {
-                    $fileName = $this->randomizeFileName($file->getNewName());
+                    $fileName = $this->randomizeFileName($file->getNewName(), $this->isPrependOriginalFileNameConfigured());
                     $file->renameName($fileName);
                 }
                 for ($i = 1; $this->isNotUniqueFilename($file); $i++) {
@@ -307,13 +307,20 @@ class UploadService implements SingletonInterface
     }
 
     /**
-     * @param string $filename
+     * @param $filename
+     * @param false $prependOriginalFileName
      * @return string
      */
-    protected function randomizeFileName(string $filename): string
+    protected function randomizeFileName($filename, $prependOriginalFileName = false): string
     {
         $fileInfo = pathinfo($filename);
-        return StringUtility::getRandomString(32, false) . '.' . $fileInfo['extension'];
+        $randomizedFileName = '';
+        if ($prependOriginalFileName) {
+            $randomizedFileName .= $fileInfo['filename'] . '-';
+        }
+        $randomizedFileName .= StringUtility::getRandomString(32, false);
+        $randomizedFileName .= '.' . $fileInfo['extension'];
+        return $randomizedFileName;
     }
 
     /**
@@ -353,6 +360,14 @@ class UploadService implements SingletonInterface
     protected function isRandomizeFileNameConfigured(): bool
     {
         return $this->settings['misc']['file']['randomizeFileName'] === '1';
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isPrependOriginalFileNameConfigured(): bool
+    {
+        return $this->settings['misc']['file']['randomizePrependOriginalFileName'] === '1';
     }
 
     /**

--- a/Configuration/TypoScript/Main/constants.typoscript
+++ b/Configuration/TypoScript/Main/constants.typoscript
@@ -219,7 +219,10 @@ plugin.tx_powermail {
 			# cat=powermail_additional//0840; type=boolean; label= Randomized Filenames: Uploaded filenames can be randomized to respect data privacy
 			randomizeFileName = 1
 
-			# cat=powermail_additional//0845; type=boolean; label= Force JavaScript Datepicker: Per default html5 Date or Datetime format is used. If you don't want to use it and want to have the same datepicker all over all browsers, you can enable this feature
+      # cat=powermail_additional//0840; type=boolean; label= Prepend original file name: Prepend original file name to randomized file name if randomizeFileName is enabled
+      randomizePrependOriginalFileName = 0
+
+      # cat=powermail_additional//0845; type=boolean; label= Force JavaScript Datepicker: Per default html5 Date or Datetime format is used. If you don't want to use it and want to have the same datepicker all over all browsers, you can enable this feature
 			forceJavaScriptDatePicker = 0
 
 			# cat=powermail_additional//0850; type=boolean; label= Debug Settings: Show all Settings from TypoScript, Flexform and Global Config in Devlog

--- a/Configuration/TypoScript/Main/setup.typoscript
+++ b/Configuration/TypoScript/Main/setup.typoscript
@@ -543,6 +543,7 @@ plugin.tx_powermail {
 					size = {$plugin.tx_powermail.settings.misc.uploadSize}
 					extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
 					randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+          randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
 				}
 
 				datepicker {

--- a/Configuration/TypoScript/Powermail_Frontend/setup.typoscript
+++ b/Configuration/TypoScript/Powermail_Frontend/setup.typoscript
@@ -33,6 +33,7 @@ plugin.tx_powermail {
 					size = {$plugin.tx_powermail.settings.misc.uploadSize}
 					extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
 					randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+          randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
 				}
 			}
 

--- a/Documentation/ForAdministrators/BestPractice/MainTypoScript.md
+++ b/Documentation/ForAdministrators/BestPractice/MainTypoScript.md
@@ -231,6 +231,9 @@ plugin.tx_powermail {
 			# cat=powermail_additional//0840; type=boolean; label= Randomized Filenames: Uploaded filenames can be randomized to respect data privacy
 			randomizeFileName = 1
 
+            # cat=powermail_additional//0840; type=boolean; label= Prepend original file name: Prepend original file name to randomized file name if randomizeFileName is enabled
+			randomizePrependOriginalFileName = 0
+
 			# cat=powermail_additional//0845; type=boolean; label= Force JavaScript Datepicker: Per default html5 Date or Datetime format is used. If you don't want to use it and want to have the same datepicker all over all browsers, you can enable this feature
 			forceJavaScriptDatePicker = 0
 
@@ -903,6 +906,7 @@ plugin.tx_powermail {
 					size = {$plugin.tx_powermail.settings.misc.uploadSize}
 					extension = {$plugin.tx_powermail.settings.misc.uploadFileExtensions}
 					randomizeFileName = {$plugin.tx_powermail.settings.misc.randomizeFileName}
+					randomizePrependOriginalFileName = {$plugin.tx_powermail.settings.misc.randomizePrependOriginalFileName}
 				}
 
 				datepicker {


### PR DESCRIPTION
…file name

 In some cases it is useful to prepend the original filename. For example if a small
 group of editors have access to `tx_powermail/uploads` and they need to download
 files manually.

 This allows to have a connection between the original filename and the randomized one.

 Be careful: It is only security by obscurity! You still need to protect your uploads
 folder with a decent `.htaccess`.
 
 Thanks to Lorenz Ulrich for the first PR ... needed a rebase to the current development branch (see #404) 