### PR TITLE
[BUGFIX] Do not require receiver mail when receiver subject is empty

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -87,13 +87,13 @@ class SendMailService
             $logger = ObjectUtility::getLogger(__CLASS__);
             $logger->info('Mail properties', [$email]);
         }
-        if (!GeneralUtility::validEmail($email['receiverEmail']) ||
-            !GeneralUtility::validEmail($email['senderEmail'])) {
-            return false;
-        }
         if (empty($email['subject'])) {
             // don't want an error flashmessage
             return true;
+        }
+        if (!GeneralUtility::validEmail($email['receiverEmail']) ||
+            !GeneralUtility::validEmail($email['senderEmail'])) {
+            return false;
         }
         return $this->prepareAndSend($email);
     }


### PR DESCRIPTION
This fixes the flash message showing "Error, Mail could not sent correctly!"
when the receiver subject and the receiver mail is empty.

Resolves: https://github.com/einpraegsam/powermail/issues/611
Obsoletes: https://github.com/einpraegsam/powermail/pull/612