### PR TITLE
Bugfix: TypeError in disclaimer action 

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -498,7 +498,7 @@ class SendMailService
         $this->mail = $mail;
         $this->settings = $settings;
         $this->configuration = $this->getConfigurationFromSettings($settings);
-        $this->overwriteConfig = $this->configuration[$type . '.']['overwrite.'];
+        $this->overwriteConfig = $this->configuration[$type . '.']['overwrite.'] ?? [];
         $mailRepository = ObjectUtility::getObjectManager()->get(MailRepository::class);
         ObjectUtility::getContentObject()->start($mailRepository->getVariablesWithMarkersFromMail($mail));
         $this->type = $type;


### PR DESCRIPTION
When i click on the disclaimer link in optin mail to delete my email data then i get the error

Argument 2 passed to In2code\Powermail\Utility\TypoScriptUtility::overwriteValueFromTypoScript() must be of the type array, null given

Reason: The disclaimer section in https://github.com/einpraegsam/powermail/blob/develop/Configuration/TypoScript/Main/setup.typoscript#L310 has no `overwrite` section.