### PR TITLE
Fix invalid return type

### DIFF
--- a/Classes/Domain/Model/Answer.php
+++ b/Classes/Domain/Model/Answer.php
@@ -228,7 +228,7 @@ class Answer extends AbstractEntity
         if (is_array($value)) {
             $value = json_encode($value);
         }
-        return $value;
+        return (string)$value;
     }
 
     /**


### PR DESCRIPTION
Ensure that the method In2code\Powermail\Domain\Model\Answer::convertToJson()
does always return a string even if a non string value like null is given.