### PR TITLE
Fix fatal errors when file size or type is not given

### DIFF
--- a/Classes/Domain/Factory/FileFactory.php
+++ b/Classes/Domain/Factory/FileFactory.php
@@ -12,6 +12,7 @@ use In2code\Powermail\Utility\ObjectUtility;
 use In2code\Powermail\Utility\StringUtility;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
+use TYPO3\CMS\Core\Type\File\FileInfo;
 use TYPO3\CMS\Extbase\Object\Exception;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException;
@@ -131,11 +132,11 @@ class FileFactory
         $file->setNewName(StringUtility::cleanString($originalName));
         $file->setUploadFolder($this->getUploadFolder());
         if ($size === 0) {
-            $size = filesize($file->getNewPathAndFilename(true));
+            $size = filesize($file->getTemporaryName());
         }
         $file->setSize((int)$size);
         if ($type === '') {
-            $type = mime_content_type($file->getNewPathAndFilename(true));
+            $type = (new FileInfo($file->getTemporaryName()))->getMimeType() ?: 'application/octet-stream';
         }
         $file->setType($type);
         $file->setUploaded($uploaded);


### PR DESCRIPTION
Could not reproduce the error with a form submit but found errors in the error log indicating that this somehow can be triggered.

```
PHP Warning: mime_content_type(...uploads/tx_powermail/stephaniewyntershhz603_gmail.com): failed to open stream: No such file or directory in ...typo3conf/ext/powermail/Classes/Domain/Factory/FileFactory.php line 138

Uncaught TYPO3 Exception: Argument 1 passed to In2code\Powermail\Domain\Model\File::setType() must be of the type string, bool given, called in ...typo3conf/ext/powermail/Classes/Domain/Factory/FileFactory.php on line 140 | TypeError thrown in file ...typo3conf/ext/powermail/Classes/Domain/Model/File.php in line 223
```

I also chose to use TYPO3 mime type API instead of the function call and to add a fallback in case even this fails, to avoid the potential fatal error.

The important fix is to use the temporary file name, as the file is not yet moved to the new location at this point, so accessing the new file location path for sure fails