### PR TITLE
[DOCS] Align with new TYPO3 documentation standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,11 @@ indent_style = tab
 indent_size = 3
 max_line_length = 80
 
+# Markdown-Files
+[*.md]
+indent_size = 4
+max_line_length = 80
+
 # YAML-Files
 [*.{yaml,yml}]
 indent_size = 2

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,66 @@
+# More information about this file:
+# https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#settings-cfg
+
+[general]
+
+project     = Powermail
+version     = main (development)
+release     = main (development)
+copyright   = since 2008 by in2code & contributors
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+github_repository    = einpraegsam/powermail
+github_branch        = master
+
+# Footer links
+project_home         = https://extensions.typo3.org/extension/powermail
+project_contact      = https://typo3.slack.com/archives/C06P2DQG2
+project_repository   = https://github.com/einpraegsam/powermail
+project_issues       = https://github.com/einpraegsam/powermail/issues
+project_discussions  =
+
+use_opensearch       =
+
+[intersphinx_mapping]
+
+# Official TYPO3 manuals
+# h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+# t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+# t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+# t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
+# t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
+# t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+# t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
+# t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+# ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
+# ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
+# ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
+# ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# TYPO3 Extension powermail
+[![Latest Stable Version](https://poser.pugx.org/in2code/powermail/v/stable)](https://extensions.typo3.org/extension/powermail/)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+[![Total Downloads](https://poser.pugx.org/in2code/powermail/d/total)](https://packagist.org/packages/in2code/powermail)
+[![Monthly Downloads](https://poser.pugx.org/in2code/powermail/d/monthly)](https://packagist.org/packages/in2code/powermail)
 
-Powermail is a well-known, editor-friendly, powerful
-and easy to use mailform extension for TYPO3 with a lots of features
-(spam prevention, marketing information, optin, ajax submit, diagram analysis, etc...)
+# TYPO3 extension `powermail`
+
+Powermail is a well-known, editor-friendly, powerful and easy-to-use mailform
+extension for TYPO3 with many features (spam protection, marketing information,
+opt-in, Ajax submit, diagram analysis, etc...).
+
+|                  | URL                                               |
+|------------------|---------------------------------------------------|
+| **Repository:**  | https://github.com/einpraegsam/powermail          |
+| **Read online:** | https://github.com/einpraegsam/powermail          |
+| **TER:**         | https://extensions.typo3.org/extension/powermail/ |
+
 
 ## TYPO3 11
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "in2code/powermail",
-	"description": "Powermail is a well-known, editor-friendly, powerful and easy to use mailform extension for TYPO3 with a lots of features",
+	"description": "Powermail is a well-known, editor-friendly, powerful and easy-to-use mailform extension for TYPO3 with many features (spam protection, marketing information, opt-in, Ajax submit, diagram analysis, etc...).",
 	"keywords": [
 		"typo3",
 		"form",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,13 @@
 		"mailform",
 		"spamprevention"
 	],
-	"homepage": "https://github.com/einpraegsam/powermail",
+	"homepage": "https://extensions.typo3.org/extension/powermail",
+	"support": {
+		"source": "https://github.com/einpraegsam/powermail",
+		"issues": "https://github.com/einpraegsam/powermail/issues",
+		"docs": "https://github.com/einpraegsam/powermail",
+		"chat": "https://typo3.slack.com/archives/C06P2DQG2"
+	},
 	"authors": [
 		{
 			"name": "Alex Kellner",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,8 +6,8 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'powermail',
     'description' => 'Powermail is a well-known, editor-friendly, powerful
-        and easy to use mailform extension with a lots of features
-        (spam prevention, marketing information, optin, ajax submit, diagram analysis, etc...)',
+        and easy-to-use mailform extension with many features
+        (spam protection, marketing information, opt-in, Ajax submit, diagram analysis, etc...).',
     'category' => 'plugin',
     'version' => '10.1.0',
     'state' => 'stable',


### PR DESCRIPTION
Hi in2code, hi Powermail team,

this PR is a suggestion to align your extension documentation with the recently introduced [TYPO3 documentation standards](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html) and the [User's Round Trip](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/UserRoundTrip.html) guide and also with similar extensions.

The focus is on having one central documentation at Documentation/ and reduce the README to an abstract, badges and further links to all important aspects of the extensions (TER, docs, VCS).

**What is missing:**
(1) Registering this documentation for rendering and publishing at https://docs.typo3.org/p/in2code/powermail/main/en-us/ with the [webhook](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocForExtension/Webhook.html#github) - to be found by the new global search at docs.typo3.org.
(2) Moving all documentation from README.md to Documentation/ - to not maintain two places and confusing the user.
(3) Transforming markdown into reST to make full use of the continuously expanded set of [documentation content elements](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference.html) of the TYPO3 Sphinx theme.

Greetings, Alex

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182 
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185