### PR TITLE
[BUGFIX] Use correct label in backend module search

### DIFF
--- a/Resources/Private/Partials/Module/Search.html
+++ b/Resources/Private/Partials/Module/Search.html
@@ -14,11 +14,12 @@
     </div>
     <div class="form-group">
         <f:if condition="{formUids -> f:count()} > 1">
-            <label for="searchall_mails">
+            <label for="searchall_form">
                 <f:translate key="BackendListFilterFulltextSearchFormFilter" default="Reduce to one form:" />
             </label>
             <f:form.select
                     property="form"
+                    id="searchall_form"
                     options="{formUids}"
                     value="{piVars.filter.form}"
                     class="form-control"


### PR DESCRIPTION
The label "Reduce to one form" needs an own id and proper relation to the field