### PR TITLE
[BUGFIX] Exclude reset-field from validation

### DIFF
--- a/Resources/Private/Build/JavaScript/FormValidation.js
+++ b/Resources/Private/Build/JavaScript/FormValidation.js
@@ -473,7 +473,7 @@ class Form {
 
   #getFieldsFromForm() {
     return this.#form.querySelectorAll(
-      'input:not([data-powermail-validation="disabled"]):not([type="hidden"]):not([type="submit"])'
+      'input:not([data-powermail-validation="disabled"]):not([type="hidden"]):not([type="reset"]):not([type="submit"])'
       + ', textarea:not([data-powermail-validation="disabled"])'
       + ', select:not([data-powermail-validation="disabled"])'
     );


### PR DESCRIPTION
**Test**
1. Form with at least one mandatory-field, reset-field and submit-field
2.  Click on submit

**current behavior without fix**
Form is submitted to server with an js-error in console ("Uncaught TypeError: e.getAttribute(...) is null") although there are validation errors.

**behavior with this fix**
Form is not submitted and js-errors are shown.