### PR TITLE
[TASK] Improve text for error_mail_not_created

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -169,7 +169,7 @@
 				<target state="translated">Diese Angaben wurden vollständig zurückgezogen:</target>
 			</trans-unit>
 			<trans-unit id="error_mail_not_created">
-				<source>Error, Mail could not sent correctly!</source>
+				<source>Error, Email could not be sent correctly!</source>
 				<target state="translated">Fehler, die Nachricht konnte leider nicht korrekt versendet werden!</target>
 			</trans-unit>
 			<trans-unit id="error_no_typoscript">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -127,7 +127,7 @@
 				<source>This data was completely disclaimed:</source>
 			</trans-unit>
 			<trans-unit id="error_mail_not_created" resname="error_mail_not_created">
-				<source>Error, Mail could not sent correctly!</source>
+				<source>Error, Email could not be sent correctly!</source>
 			</trans-unit>
 			<trans-unit id="error_no_typoscript" resname="error_no_typoscript">
 				<source>TypoScript settings are missing. Did you include the related static templates?</source>


### PR DESCRIPTION
Minor spelling and grammar fix.

------

Not in commit message:
    
Usually, in the other texts, the word "email" is used, instead
of "mail", so this was changed as well.
    
In other texts there is some capitalization of the main term,
so Email was capitalized as well (even though grammatically
this might not be correct except for titles or common names).
