### PR TITLE
[BUGFIX] Exclude GetLocationEid class from service autowiring to avoid null island cli output

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,3 +6,4 @@ services:
 
   In2code\Powermail\:
     resource: '../Classes/*'
+    exclude: '../Classes/Eid/GetLocationEid.php'


### PR DESCRIPTION
see https://github.com/einpraegsam/powermail/issues/721#issuecomment-1431508472